### PR TITLE
Manually draw and delete the image cache from the ImageView

### DIFF
--- a/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/fragments/CardViewFragment.java
+++ b/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/fragments/CardViewFragment.java
@@ -994,7 +994,7 @@ public class CardViewFragment extends FamiliarFragment {
 
 			FileOutputStream fStream = new FileOutputStream(fPath);
 
-			mCopyImageView.setDrawingCacheEnabled(true);
+			mCopyImageView.buildDrawingCache();
 
 			Bitmap bmpImage = mCopyImageView.getDrawingCache();
 
@@ -1005,7 +1005,11 @@ public class CardViewFragment extends FamiliarFragment {
 				return;
 			}
 
-			if (!bmpImage.compress(Bitmap.CompressFormat.JPEG, 80, fStream)) {
+            boolean bCompressed = bmpImage.compress(Bitmap.CompressFormat.JPEG, 80, fStream);
+
+            mCopyImageView.destroyDrawingCache();
+
+			if (!bCompressed) {
 				Toast.makeText(mActivity, getString(R.string.card_view_unable_to_save_image),
 						Toast.LENGTH_LONG).show();
 


### PR DESCRIPTION
This should resolve issue #32. I was building the image cache based on the first image in the view and then never rebuilding it. Rather than keep turning the cache on and off, we save some CPU cycles by manually building and then destroying the cache only when we need it.
