### PR TITLE
Scheme cards appearing in Card Search Results

### DIFF
--- a/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/helpers/database/CardDbAdapter.java
+++ b/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/helpers/database/CardDbAdapter.java
@@ -1037,7 +1037,7 @@ public class CardDbAdapter {
 						" AND NOT " + DATABASE_TABLE_CARDS + "." + KEY_SET + " = 'UG'" +
 						" AND " + DATABASE_TABLE_CARDS + "." + KEY_TYPE + " NOT LIKE 'Plane %'" +
 						" AND " + DATABASE_TABLE_CARDS + "." + KEY_TYPE + " NOT LIKE 'Conspiracy%'" +
-						" AND " + DATABASE_TABLE_CARDS + "." + KEY_TYPE + " NOT LIKE 'Scheme%'" +
+						" AND " + DATABASE_TABLE_CARDS + "." + KEY_TYPE + " NOT LIKE '%Scheme%'" +
 						" AND " + DATABASE_TABLE_CARDS + "." + KEY_TYPE + " NOT LIKE 'Vanguard%'";
 			}
 			statement += " AND NOT EXISTS (SELECT * FROM "


### PR DESCRIPTION
Old exclusion of Scheme cards only filtered out cards whose types started with "Scheme", excluding "Ongoing Scheme"

Issue #46 