### PR TITLE
Backup Helper and proguard

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -12,7 +12,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" assert-keyword="true" jdk-15="true" project-jdk-name="1.7" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" assert-keyword="true" jdk-15="true" project-jdk-name="1.7" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
 </project>

--- a/MTGFamiliar/build.gradle
+++ b/MTGFamiliar/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0-rc4'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 apply plugin: 'com.android.application'
@@ -24,6 +24,14 @@ android {
         exclude 'META-INF/NOTICE.txt'
     }
     productFlavors {
+    }
+    buildTypes {
+        release {
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
+            zipAlignEnabled true
+        }
     }
 }
 

--- a/MTGFamiliar/src/main/AndroidManifest.xml
+++ b/MTGFamiliar/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
+        android:backupAgent=".helpers.BackupHelper"
         android:theme="@style/Theme.light">
         <activity
             android:name="com.gelakinetic.mtgfam.FamiliarActivity"
@@ -28,6 +29,12 @@
             <meta-data
                 android:name="android.app.searchable"
                 android:resource="@xml/searchable"/>
+
+            <!-- Registering for the backup service -->
+            <!-- todo: add backup key here -->
+            <meta-data
+                android:name="com.google.android.backup.api_key"
+                android:value="" />
 
             <!-- enable the search dialog to send searches to SearchableActivity -->
             <meta-data

--- a/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/helpers/BackupHelper.java
+++ b/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/helpers/BackupHelper.java
@@ -1,0 +1,25 @@
+package com.gelakinetic.mtgfam.helpers;
+
+import android.app.backup.BackupAgentHelper;
+import android.app.backup.SharedPreferencesBackupHelper;
+
+/**
+ * Created by XVicarious on 1/26/2015.
+ */
+public class BackupHelper extends BackupAgentHelper {
+    // The name of the preferences file (and then the wishlist)
+    static final String PREFS = "com.gelakinetic.mtgfam_preferences.xml";
+    static final String WISHLIST = "card.wishlist";  // add other files here such as IPG.html, MTR.html if you choose
+
+    // A key for the preferences (and then the wishlist, and other files)
+    static final String PREFS_BACKUP_KEY = "prefs";
+    static final String WISHLIST_BACKUP_KEY = "files";
+
+    @Override
+    public void onCreate() {
+        SharedPreferencesBackupHelper backupPrefs = new SharedPreferencesBackupHelper(this, PREFS);
+        SharedPreferencesBackupHelper backupWishlist = new SharedPreferencesBackupHelper(this, WISHLIST); // Add additional arguments as filenames to backup to this
+        addHelper(PREFS_BACKUP_KEY, backupPrefs);
+        addHelper(WISHLIST_BACKUP_KEY, backupWishlist);
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Nov 12 10:48:32 PST 2014
+#Mon Jan 26 16:49:34 EST 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/mtg-familiar.iml
+++ b/mtg-familiar.iml
@@ -7,7 +7,9 @@
       </configuration>
     </facet>
   </component>
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
+  <component name="NewModuleRootManager" inherit-compiler-output="false">
+    <output url="file://$MODULE_DIR$/build/classes/main" />
+    <output-test url="file://$MODULE_DIR$/build/classes/test" />
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.gradle" />
     </content>


### PR DESCRIPTION
First off:
backup helper, this will let people who have multiple devices sync between devices or people who get a new phone don't have to lose their wishlist and preferences.
AEFeinstein: this will require your direct intervention as you have to register MTGFamiliar for backup service here: http://developer.android.com/google/backup/signup.html
Secondly:
proguard,  I enabled this while playing around building this and I shaved what I believe to be about 1MB off of the APK.  Correct me if I'm wrong with that.
edit; I MAY be wrong.  I forgot about adding classes that are only referenced in the manifest to proguard's configuration.  For instance BackupHelper will be excluded on build if it isn't added to proguard-rules.txt in the MTGFamiliar directory.