### PR TITLE
add material design icon

### DIFF
--- a/art/mtgfam-icon-material.svg
+++ b/art/mtgfam-icon-material.svg
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="314"
+   width="329.6875"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="mtgfam-icon-new.svg"
+   inkscape:export-filename="C:\Users\Adam Feinstein\Desktop\icons.png"
+   inkscape:export-xdpi="474.26001"
+   inkscape:export-ydpi="474.26001">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8">
+    <clipPath
+       id="presentation_clip_path"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         x="0"
+         y="0"
+         width="14183"
+         height="14356"
+         id="rect4277" />
+    </clipPath>
+    <g
+       id="bullet-char-template57356"
+       transform="scale(0.00048828125,-0.00048828125)">
+      <path
+         d="M 580,1141 L 1163,571 580,0 -4,571 580,1141 Z"
+         id="path4284" />
+    </g>
+    <g
+       id="bullet-char-template57354"
+       transform="scale(0.00048828125,-0.00048828125)">
+      <path
+         d="M 8,1128 L 1137,1128 1137,0 8,0 8,1128 Z"
+         id="path4287" />
+    </g>
+    <g
+       id="bullet-char-template10146"
+       transform="scale(0.00048828125,-0.00048828125)">
+      <path
+         d="M 174,0 L 602,739 174,1481 1456,739 174,0 Z M 1358,739 L 309,1346 659,739 1358,739 Z"
+         id="path4290" />
+    </g>
+    <g
+       id="bullet-char-template10132"
+       transform="scale(0.00048828125,-0.00048828125)">
+      <path
+         d="M 2015,739 L 1276,0 717,0 1260,543 174,543 174,936 1260,936 717,1481 1274,1481 2015,739 Z"
+         id="path4293" />
+    </g>
+    <g
+       id="bullet-char-template10007"
+       transform="scale(0.00048828125,-0.00048828125)">
+      <path
+         d="M 0,-2 C -7,14 -16,27 -25,37 L 356,567 C 262,823 215,952 215,954 215,979 228,992 255,992 264,992 276,990 289,987 310,991 331,999 354,1012 L 381,999 492,748 772,1049 836,1024 860,1049 C 881,1039 901,1025 922,1006 886,937 835,863 770,784 769,783 710,716 594,584 L 774,223 C 774,196 753,168 711,139 L 727,119 C 717,90 699,76 672,76 641,76 570,178 457,381 L 164,-76 C 142,-110 111,-127 72,-127 30,-127 9,-110 8,-76 1,-67 -2,-52 -2,-32 -2,-23 -1,-13 0,-2 Z"
+         id="path4296" />
+    </g>
+    <g
+       id="bullet-char-template10004"
+       transform="scale(0.00048828125,-0.00048828125)">
+      <path
+         d="M 285,-33 C 182,-33 111,30 74,156 52,228 41,333 41,471 41,549 55,616 82,672 116,743 169,778 240,778 293,778 328,747 346,684 L 369,508 C 377,444 397,411 428,410 L 1163,1116 C 1174,1127 1196,1133 1229,1133 1271,1133 1292,1118 1292,1087 L 1292,965 C 1292,929 1282,901 1262,881 L 442,47 C 390,-6 338,-33 285,-33 Z"
+         id="path4299" />
+    </g>
+    <g
+       id="bullet-char-template9679"
+       transform="scale(0.00048828125,-0.00048828125)">
+      <path
+         d="M 813,0 C 632,0 489,54 383,161 276,268 223,411 223,592 223,773 276,916 383,1023 489,1130 632,1184 813,1184 992,1184 1136,1130 1245,1023 1353,916 1407,772 1407,592 1407,412 1353,268 1245,161 1136,54 992,0 813,0 Z"
+         id="path4302" />
+    </g>
+    <g
+       id="bullet-char-template8226"
+       transform="scale(0.00048828125,-0.00048828125)">
+      <path
+         d="M 346,457 C 273,457 209,483 155,535 101,586 74,649 74,723 74,796 101,859 155,911 209,963 273,989 346,989 419,989 480,963 531,910 582,859 608,796 608,723 608,648 583,586 532,535 482,483 420,457 346,457 Z"
+         id="path4305" />
+    </g>
+    <g
+       id="bullet-char-template8211"
+       transform="scale(0.00048828125,-0.00048828125)">
+      <path
+         d="M -4,459 L 1135,459 1135,606 -4,606 -4,459 Z"
+         id="path4308" />
+    </g>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1440"
+     inkscape:window-height="768"
+     id="namedview6"
+     showgrid="false"
+     inkscape:zoom="0.60637875"
+     inkscape:cx="270.64387"
+     inkscape:cy="224.51939"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     fit-margin-top="5"
+     fit-margin-left="5"
+     fit-margin-right="5"
+     fit-margin-bottom="5"
+     showguides="true"
+     inkscape:guide-bbox="true" />
+  <g
+     id="g5279"
+     transform="matrix(1.7496065,0,0,1.7496065,-24.113739,-329.3906)">
+    <g
+       transform="translate(-388.00001,172)"
+       id="g5082">
+      <path
+         style="fill:#fafafa;fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0"
+         d="m 496,194.00001 c -16.20067,0 -29.96938,-3.6916 -44,-11.78572 -14.03061,-8.10657 -24.10771,-18.18367 -32.21428,-32.21428 C 411.6916,135.96939 408,122.20069 408,106.00001 408,89.799324 411.6916,76.030618 419.78572,62.000004 427.89229,47.96939 437.96939,37.892289 452,29.785718 466.03062,21.691612 479.79933,18 496,18 c 16.20069,0 29.96939,3.691612 44.00001,11.785718 14.03061,8.106571 24.10771,18.183672 32.21428,32.214286 8.09411,14.030614 11.78572,27.79932 11.78572,44.000006 0,16.20068 -3.69161,29.96938 -11.78572,44 -8.10657,14.03061 -18.18367,24.10771 -32.21428,32.21428 -14.03062,8.09412 -27.79932,11.78572 -44.00001,11.78572 l 0,0 z"
+         id="path5084" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path5086"
+         d="m 408.03125,104 c -0.0129,0.66681 -0.0312,1.32493 -0.0312,2 0,16.20068 3.68713,29.96938 11.78125,44 8.10657,14.03061 18.18814,24.11218 32.21875,32.21875 C 466.03062,190.31287 479.79933,194 496,194 c 16.20069,0 29.96938,-3.68713 44,-11.78125 C 554.03061,174.11218 564.11218,164.03061 572.21875,150 580.31286,135.96938 584,122.20068 584,106 c 0,-0.67507 -0.0184,-1.33319 -0.0312,-2 -0.29601,15.33587 -3.99316,28.55402 -11.75,42 C 564.11218,160.03061 554.03061,170.11218 540,178.21875 525.96938,186.31287 512.20069,190 496,190 479.79933,190 466.03062,186.31287 452,178.21875 437.96939,170.11218 427.88782,160.03061 419.78125,146 c -7.75685,-13.44598 -11.45399,-26.66413 -11.75,-42 z"
+         style="fill:#212121;fill-opacity:0.10196078;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path5088"
+         d="M 496,18 C 479.79933,18 466.03062,21.687144 452,29.78125 437.96939,37.887821 427.88782,47.969386 419.78125,62 411.68713,76.030614 408,89.799314 408,106 c 0,0.67506 0.0184,1.33319 0.0312,2 0.29601,-15.335873 3.99315,-28.554027 11.75,-42 C 427.88782,51.969386 437.96939,41.887821 452,33.78125 466.03062,25.687144 479.79933,22 496,22 c 16.20069,0 29.96938,3.687144 44,11.78125 14.03061,8.106571 24.11218,18.188136 32.21875,32.21875 7.75684,13.445973 11.45399,26.664127 11.75,42 C 583.98162,107.33319 584,106.67506 584,106 584,89.799314 580.31286,76.030614 572.21875,62 564.11218,47.969386 554.03061,37.887821 540,29.78125 525.96938,21.687144 512.20069,18 496,18 z"
+         style="fill:#ffffff;fill-opacity:0.4;stroke:none" />
+    </g>
+    <g
+       id="g5160">
+      <path
+         id="path5092"
+         d="m 108.03743,283.80717 -40.361003,55.55699 80.721993,0 -40.36099,-55.55699 z"
+         style="fill:#616161;fill-opacity:1;stroke:#616161;stroke-width:4;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path5094"
+         d="m 180.97281,258.5067 -65.31044,21.23128 40.36099,55.54352 24.94945,-76.7748 z"
+         style="fill:#1976d2;fill-opacity:1;stroke:#1976d2;stroke-width:4;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path5096"
+         d="m 112.7,202.65206 0,68.66487 65.29698,-21.21781 L 112.7,202.65206 z"
+         style="fill:#e0e0e0;fill-opacity:1;stroke:#e0e0e0;stroke-width:4;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path5098"
+         d="M 103.59698,202.65206 38.3,250.09912 l 65.29698,21.21781 0,-68.66487 z"
+         style="fill:#4caf50;fill-opacity:1;stroke:#4caf50;stroke-width:4;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path5100"
+         d="M 35.102041,258.5067 60.051488,335.2815 100.41248,279.73798 35.102041,258.5067 z"
+         style="fill:#f44336;fill-opacity:1;stroke:#f44336;stroke-width:4;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Following the spec at
http://www.google.com/design/spec/style/icons.html, tweak the icon to
comply with material design.

Major changes:
- use of colors from MD palette:
  http://www.google.com/design/spec/style/color.html
- addition of quantum paper circle backdrop
- slight rounding of pie colors