### PR TITLE
toasts now replace each other

### DIFF
--- a/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/FamiliarActivity.java
+++ b/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/FamiliarActivity.java
@@ -65,7 +65,7 @@ import android.widget.ArrayAdapter;
 import android.widget.ImageView;
 import android.widget.ListView;
 import android.widget.TextView;
-import android.widget.Toast;
+import com.gelakinetic.mtgfam.helpers.Toast;
 
 import com.alertdialogpro.AlertDialogPro;
 import com.gelakinetic.mtgfam.fragments.CardViewPagerFragment;
@@ -251,6 +251,7 @@ public class FamiliarActivity extends ActionBarActivity {
     protected void onStop() {
         super.onStop();
         mSpiceManager.shouldStop();
+        Toast.cancelToast();
     }
 
     @Override

--- a/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/fragments/CardViewFragment.java
+++ b/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/fragments/CardViewFragment.java
@@ -56,7 +56,7 @@ import android.widget.ListView;
 import android.widget.ScrollView;
 import android.widget.SimpleAdapter;
 import android.widget.TextView;
-import android.widget.Toast;
+import com.gelakinetic.mtgfam.helpers.Toast;
 
 import com.alertdialogpro.AlertDialogPro;
 import com.gelakinetic.mtgfam.FamiliarActivity;

--- a/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/fragments/DiceFragment.java
+++ b/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/fragments/DiceFragment.java
@@ -14,7 +14,7 @@ import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.TextSwitcher;
 import android.widget.TextView;
-import android.widget.Toast;
+import com.gelakinetic.mtgfam.helpers.Toast;
 import android.widget.ViewSwitcher;
 
 import com.alertdialogpro.AlertDialogPro;

--- a/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/fragments/FamiliarFragment.java
+++ b/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/fragments/FamiliarFragment.java
@@ -16,7 +16,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Toast;
+import com.gelakinetic.mtgfam.helpers.Toast;
 
 import com.gelakinetic.mtgfam.FamiliarActivity;
 import com.gelakinetic.mtgfam.R;

--- a/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/fragments/GatheringsFragment.java
+++ b/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/fragments/GatheringsFragment.java
@@ -32,7 +32,7 @@ import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.Spinner;
 import android.widget.TextView;
-import android.widget.Toast;
+import com.gelakinetic.mtgfam.helpers.Toast;
 
 import com.alertdialogpro.AlertDialogPro;
 import com.gelakinetic.mtgfam.FamiliarActivity;

--- a/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/fragments/LifeCounterFragment.java
+++ b/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/fragments/LifeCounterFragment.java
@@ -20,7 +20,7 @@ import android.view.WindowManager;
 import android.widget.GridLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
-import android.widget.Toast;
+import com.gelakinetic.mtgfam.helpers.Toast;
 
 import com.alertdialogpro.AlertDialogPro;
 import com.gelakinetic.mtgfam.FamiliarActivity;

--- a/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/fragments/ManaPoolFragment.java
+++ b/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/fragments/ManaPoolFragment.java
@@ -9,7 +9,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.TextView;
-import android.widget.Toast;
+import com.gelakinetic.mtgfam.helpers.Toast;
 
 import com.gelakinetic.mtgfam.R;
 

--- a/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/fragments/ProfileFragment.java
+++ b/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/fragments/ProfileFragment.java
@@ -35,7 +35,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.EditText;
 import android.widget.TextView;
-import android.widget.Toast;
+import com.gelakinetic.mtgfam.helpers.Toast;
 
 import com.alertdialogpro.AlertDialogPro;
 import com.gelakinetic.mtgfam.FamiliarActivity;

--- a/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/fragments/ResultListFragment.java
+++ b/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/fragments/ResultListFragment.java
@@ -15,7 +15,7 @@ import android.widget.AbsListView;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemClickListener;
 import android.widget.ListView;
-import android.widget.Toast;
+import com.gelakinetic.mtgfam.helpers.Toast;
 
 import com.gelakinetic.mtgfam.R;
 import com.gelakinetic.mtgfam.helpers.ResultListAdapter;

--- a/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/fragments/RulesFragment.java
+++ b/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/fragments/RulesFragment.java
@@ -29,7 +29,7 @@ import android.widget.ListView;
 import android.widget.SectionIndexer;
 import android.widget.TextView;
 import android.widget.TextView.BufferType;
-import android.widget.Toast;
+import com.gelakinetic.mtgfam.helpers.Toast;
 
 import com.alertdialogpro.AlertDialogPro;
 import com.gelakinetic.mtgfam.FamiliarActivity;

--- a/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/fragments/SearchViewFragment.java
+++ b/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/fragments/SearchViewFragment.java
@@ -24,7 +24,7 @@ import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.Spinner;
 import android.widget.TextView;
-import android.widget.Toast;
+import com.gelakinetic.mtgfam.helpers.Toast;
 
 import com.alertdialogpro.AlertDialogPro;
 import com.gelakinetic.mtgfam.FamiliarActivity;

--- a/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/fragments/TradeFragment.java
+++ b/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/fragments/TradeFragment.java
@@ -22,7 +22,7 @@ import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.ListView;
 import android.widget.TextView;
-import android.widget.Toast;
+import com.gelakinetic.mtgfam.helpers.Toast;
 
 import com.alertdialogpro.AlertDialogPro;
 import com.gelakinetic.mtgfam.FamiliarActivity;

--- a/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/fragments/WishlistFragment.java
+++ b/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/fragments/WishlistFragment.java
@@ -24,7 +24,7 @@ import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.TextView;
-import android.widget.Toast;
+import com.gelakinetic.mtgfam.helpers.Toast;
 
 import com.alertdialogpro.AlertDialogPro;
 import com.gelakinetic.mtgfam.FamiliarActivity;

--- a/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/helpers/Toast.java
+++ b/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/helpers/Toast.java
@@ -1,0 +1,67 @@
+package com.gelakinetic.mtgfam.helpers;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.support.annotation.NonNull;
+
+/**
+ * Toast that cancels when new toast shows
+ */
+public class Toast extends android.widget.Toast {
+
+    private static android.widget.Toast toast;
+
+    public Toast(Context context) {
+        super(context);
+    }
+
+    /**
+     * Cancel current toast if present
+     */
+    public static void cancelToast() {
+        if (toast != null) {
+            toast.cancel();
+        }
+    }
+
+    /**
+     * Make a standard toast that just contains a text view.
+     *
+     * @param context  The context to use.  Usually your {@link android.app.Application}
+     *                 or {@link android.app.Activity} object.
+     * @param text     The text to show.  Can be formatted text.
+     * @param duration How long to display the message.  Either {@link #LENGTH_SHORT} or
+     *                 {@link #LENGTH_LONG}
+     */
+    @NonNull
+    public static android.widget.Toast makeText(@NonNull Context context, CharSequence text,
+                                                int duration) {
+        if (toast != null) {
+            toast.cancel();
+        }
+        toast = android.widget.Toast.makeText(context, text, duration);
+        return toast;
+    }
+
+    /**
+     * Make a standard toast that just contains a text view with the text from a resource.
+     *
+     * @param context  The context to use.  Usually your {@link android.app.Application}
+     *                 or {@link android.app.Activity} object.
+     * @param resId    The resource id of the string resource to use.  Can be formatted text.
+     * @param duration How long to display the message.  Either {@link #LENGTH_SHORT} or
+     *                 {@link #LENGTH_LONG}
+     * @throws Resources.NotFoundException if the resource can't be found.
+     */
+    @NonNull
+    public static android.widget.Toast makeText(@NonNull Context context, int resId,
+                                                int duration)
+            throws Resources.NotFoundException {
+        if (toast != null) {
+            toast.cancel();
+        }
+        toast = android.widget.Toast.makeText(context, resId, duration);
+        return toast;
+    }
+
+}

--- a/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/helpers/WishlistHelpers.java
+++ b/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/helpers/WishlistHelpers.java
@@ -10,7 +10,7 @@ import android.view.View;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.TextView;
-import android.widget.Toast;
+import com.gelakinetic.mtgfam.helpers.Toast;
 
 import com.alertdialogpro.AlertDialogPro;
 import com.gelakinetic.mtgfam.R;

--- a/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/helpers/ZipUtils.java
+++ b/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/helpers/ZipUtils.java
@@ -2,7 +2,7 @@ package com.gelakinetic.mtgfam.helpers;
 
 import android.content.Context;
 import android.os.Environment;
-import android.widget.Toast;
+import com.gelakinetic.mtgfam.helpers.Toast;
 
 import com.gelakinetic.mtgfam.R;
 

--- a/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/helpers/gatherings/GatheringsIO.java
+++ b/MTGFamiliar/src/main/java/com/gelakinetic/mtgfam/helpers/gatherings/GatheringsIO.java
@@ -2,7 +2,7 @@ package com.gelakinetic.mtgfam.helpers.gatherings;
 
 import android.content.Context;
 import android.util.Xml;
-import android.widget.Toast;
+import com.gelakinetic.mtgfam.helpers.Toast;
 
 import com.gelakinetic.mtgfam.R;
 


### PR DESCRIPTION
This is imo the easiest and safest way to achieve this replacement in your code. It's something similar to a wrapper, but not quite it. To create a toast, now the app calls the static methods of this new class instead of android.widget.Toast. I've also included in the activity's onStop() the cancel of a showing toast.

Rename the new class to your liking, but if you do remember to use it instead of android.widget.Toast. 