### PR TITLE
Change versionName instead of packageName.

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -12,6 +12,10 @@ repositories {
     mavenCentral()
 }
 
+def computeVersionName() {
+    return "3.2.7"
+}
+
 android {
     compileSdkVersion 23
     buildToolsVersion '23.0.1'
@@ -19,6 +23,8 @@ android {
         applicationId = "com.gelakinetic.mtgfam"
         minSdkVersion 14
         targetSdkVersion 23
+        versionCode 36
+        versionName computeVersionName()
     }
     packagingOptions {
         exclude 'META-INF/LICENSE.txt'
@@ -30,19 +36,15 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'),
                     'proguard-rules.txt'
         }
-        debug {
-            applicationIdSuffix ".debug"
-        }
     }
     productFlavors {
         standard {
-            applicationId = "com.gelakinetic.mtgfam"
             dependencies {
                 compile 'com.google.android.gms:play-services-appindexing:7.8.0'
             }
         }
         foss {
-            applicationId = "com.gelakinetic.mtgfam.foss"
+            versionName computeVersionName() + "-foss"
         }
     }
 }

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.gelakinetic.mtgfam"
-    android:versionCode="36"
-    android:versionName="3.2.7">
+    package="com.gelakinetic.mtgfam">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />


### PR DESCRIPTION
See #106.
This moves both versionName and versionCode from the manifest to grade so that only one file needs changing for a version bump.