### PR TITLE
Fix build problem

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -1,11 +1,3 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
-    }
-}
 apply plugin: 'com.android.application'
 
 repositories {


### PR DESCRIPTION
The problem was that the 2.2.0 version of the library coudln't be
found in the maven central repo. As the upper level build.gradle
already handles the library, there is no need for the whole section
to be there in the first place.