### PR TITLE
Hacky Fix to #157

### DIFF
--- a/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/CardViewFragment.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/CardViewFragment.java
@@ -41,7 +41,9 @@ import android.os.Environment;
 import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
+import android.text.Html;
 import android.text.Html.ImageGetter;
+import android.text.SpannableString;
 import android.text.method.LinkMovementMethod;
 import android.util.TypedValue;
 import android.view.ContextMenu;
@@ -789,7 +791,6 @@ public class CardViewFragment extends FamiliarFragment {
     public boolean onContextItemSelected(android.view.MenuItem item) {
         if (getUserVisibleHint()) {
             String copyText = null;
-            // todo: Glyph->Text for cost and ability text
             switch (item.getItemId()) {
                 case R.id.copy: {
                     copyText = mCopyString;
@@ -805,11 +806,14 @@ public class CardViewFragment extends FamiliarFragment {
                             mPowTouTextView.getText() != null &&
                             mArtistTextView.getText() != null &&
                             mNumberTextView.getText() != null) {
+                        // Hacky, but it works
+                        String costText = convertHtmlToPlainText(Html.toHtml(new SpannableString(mCostTextView.getText())));
+                        String abilityText = convertHtmlToPlainText(Html.toHtml(new SpannableString(mAbilityTextView.getText())));
                         copyText = mNameTextView.getText().toString() + '\n' +
-                                mCostTextView.getText().toString() + '\n' +
+                                costText + '\n' +
                                 mTypeTextView.getText().toString() + '\n' +
                                 mSetTextView.getText().toString() + '\n' +
-                                mAbilityTextView.getText().toString() + '\n' +
+                                abilityText + '\n' +
                                 mFlavorTextView.getText().toString() + '\n' +
                                 mPowTouTextView.getText().toString() + '\n' +
                                 mArtistTextView.getText().toString() + '\n' +
@@ -833,6 +837,21 @@ public class CardViewFragment extends FamiliarFragment {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Converts some html to plain text, replacing images with their textual counterparts
+     *
+     * @param html html to be converted
+     * @return plain text representation of the input
+     */
+    public String convertHtmlToPlainText(String html) {
+        Document document = Jsoup.parse(html);
+        Elements images = document.select("img");
+        for (Element image : images) {
+            image.html("{" + image.attr("src") + "}");
+        }
+        return document.text();
     }
 
     /**

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/dialogs/CardViewDialogFragment.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/dialogs/CardViewDialogFragment.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.text.Html;
+import android.text.SpannableString;
 import android.text.method.LinkMovementMethod;
 import android.view.View;
 import android.view.Window;
@@ -224,12 +225,15 @@ public class CardViewDialogFragment extends FamiliarDialogFragment {
                             @Override
                             public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
                                 View view = getCardViewFragment().getView();
-                                // todo: Glyph->Text for cost and ability texts
+                                SpannableString costSpannable = new SpannableString(((TextView) view.findViewById(R.id.cost)).getText());
+                                SpannableString abilitySpannable = new SpannableString(((TextView) view.findViewById(R.id.ability)).getText());
+                                String costText = getCardViewFragment().convertHtmlToPlainText(Html.toHtml(costSpannable));
+                                String abilityText = getCardViewFragment().convertHtmlToPlainText(Html.toHtml(abilitySpannable));
                                 String copyText = ((TextView) view.findViewById(R.id.name)).getText().toString() + '\n' +
-                                        ((TextView) view.findViewById(R.id.cost)).getText().toString() + '\n' +
+                                        costText + '\n' +
                                         ((TextView) view.findViewById(R.id.type)).getText().toString() + '\n' +
                                         ((TextView) view.findViewById(R.id.set)).getText().toString() + '\n' +
-                                        ((TextView) view.findViewById(R.id.ability)).getText().toString() + '\n' +
+                                        abilityText + '\n' +
                                         ((TextView) view.findViewById(R.id.flavor)).getText().toString() + '\n' +
                                         ((TextView) view.findViewById(R.id.pt)).getText().toString() + '\n' +
                                         ((TextView) view.findViewById(R.id.artist)).getText().toString() + '\n' +


### PR DESCRIPTION
This fixes #157, but at the same time is extremely hacky. Any idea of how to streamline this better? I spent the better part of 3 hours researching how to go from a SpannableString to a normal String, and it all lead me to this solution. Doing a simple `view.getText().toString()` leaves you with undefined symbols in the place of the glyphs.

Basically what I ended up doing was converting the `CharSequence` to a `SpannableString` to HTML, then replacing all the image tags with their textual counterparts. I'm not particularly proud of this work, however.