### PR TITLE
Filter Out Un- & Tokens from MoJhoSto Basic #160

### DIFF
--- a/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/MoJhoStoFragment.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/MoJhoStoFragment.java
@@ -210,6 +210,7 @@ public class MoJhoStoFragment extends FamiliarFragment {
             criteria.type = type;
             criteria.cmc = cmc;
             criteria.cmcLogic = logic;
+            criteria.noTokens = true;
             Cursor permanents = CardDbAdapter.Search(criteria, false, returnTypes, true, null, database);
 
             if (permanents == null) {

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/MoJhoStoFragment.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/MoJhoStoFragment.java
@@ -210,7 +210,7 @@ public class MoJhoStoFragment extends FamiliarFragment {
             criteria.type = type;
             criteria.cmc = cmc;
             criteria.cmcLogic = logic;
-            criteria.noTokens = true;
+            criteria.moJhoStoFilter = true;
             Cursor permanents = CardDbAdapter.Search(criteria, false, returnTypes, true, null, database);
 
             if (permanents == null) {

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/SearchCriteria.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/SearchCriteria.java
@@ -32,4 +32,5 @@ public class SearchCriteria implements Serializable {
     public String collectorsNumber = null;
     public String colorIdentity = "wubrgl";
     public int colorIdentityLogic = 0;
+    public boolean noTokens;
 }

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/SearchCriteria.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/SearchCriteria.java
@@ -32,5 +32,5 @@ public class SearchCriteria implements Serializable {
     public String collectorsNumber = null;
     public String colorIdentity = "wubrgl";
     public int colorIdentityLogic = 0;
-    public boolean noTokens;
+    public boolean moJhoStoFilter;
 }

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/database/CardDbAdapter.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/database/CardDbAdapter.java
@@ -1249,12 +1249,15 @@ public class CardDbAdapter {
                     + " " + criteria.cmc + ")";
         }
 
-        if (criteria.noTokens) {
+        if (criteria.moJhoStoFilter) {
+            /* Filter out tokens. */
             statement += " AND (" +
-                        "(NOT " + DATABASE_TABLE_CARDS + "." + KEY_MANACOST + " = '') " +
-                        "OR " + DATABASE_TABLE_CARDS + "." + KEY_SUPERTYPE + " LIKE '%Land%' " +
-                        "OR " + DATABASE_TABLE_CARDS + "." + KEY_ABILITY + " LIKE '%Suspend%' " +
-                        "OR " + DATABASE_TABLE_CARDS + "." + KEY_ABILITY + " LIKE '%Splice onto Arcane%')";
+                    /* Cards without mana costs. */
+                    "NOT " + DATABASE_TABLE_CARDS + "." + KEY_MANACOST + " = '' " +
+                    /* Cards like 'Dryad Arbor'. */
+                    "OR " + DATABASE_TABLE_CARDS + "." + KEY_SUPERTYPE + " LIKE '%Land Creature%')";
+            /* Filter out 'UN-'sets*/
+            statement += " AND NOT " + DATABASE_TABLE_CARDS + "." + KEY_SET + " IN ('UG', 'UNH')";
         }
 
         if (criteria.rarity != null) {

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/database/CardDbAdapter.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/database/CardDbAdapter.java
@@ -1249,6 +1249,14 @@ public class CardDbAdapter {
                     + " " + criteria.cmc + ")";
         }
 
+        if (criteria.noTokens) {
+            statement += " AND (" +
+                        "(NOT " + DATABASE_TABLE_CARDS + "." + KEY_MANACOST + " = '') " +
+                        "OR " + DATABASE_TABLE_CARDS + "." + KEY_SUPERTYPE + " LIKE '%Land%' " +
+                        "OR " + DATABASE_TABLE_CARDS + "." + KEY_ABILITY + " LIKE '%Suspend%' " +
+                        "OR " + DATABASE_TABLE_CARDS + "." + KEY_ABILITY + " LIKE '%Splice onto Arcane%')";
+        }
+
         if (criteria.rarity != null) {
             statement += " AND (";
 


### PR DESCRIPTION
I think UNsets are already filtered out. Whether a card is a token is now taken into account in the query; Tokens do not have a mana cost. Cards without a mana cost are either lands (and possibly other types, like Dryad Arbor), have "suspend" (Lotus Bloom) or "splice onto arcane" (Evermind).