### PR TITLE
Fixes #246; Replace any non-word characters with _

### DIFF
--- a/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/DecklistHelpers.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/DecklistHelpers.java
@@ -64,7 +64,8 @@ public class DecklistHelpers {
 
         try {
 
-            final String newFileName = fileName.replaceAll("(\\s)", "_");
+            final String newFileName =
+                    fileName.replaceAll("(\\s)", "_").replaceAll("[^\\w.-]", "_");
             FileOutputStream fos = mCtx.openFileOutput(newFileName, Context.MODE_PRIVATE);
 
             /* For each compressed card, make an MtgCard and write it to the default decklist */


### PR DESCRIPTION
Illegal Argument exceptions thrown from "makeFilename" are result of illegal characters in the filename.

This should also be applied to the trade filename.