### PR TITLE
Reworked clearTextAndTokens

### DIFF
--- a/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/CardViewFragment.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/CardViewFragment.java
@@ -99,6 +99,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Locale;
 
@@ -259,7 +260,7 @@ public class CardViewFragment extends FamiliarFragment {
             public void onClick(View v) {
                 SearchCriteria setSearch = new SearchCriteria();
                 assert mSetTextView.getText() != null;
-                setSearch.set = mSetTextView.getText().toString();
+                setSearch.sets = Collections.singletonList(mSetTextView.getText().toString());
                 Bundle arguments = new Bundle();
                 arguments.putSerializable(SearchViewFragment.CRITERIA, setSearch);
                 ResultListFragment rlFrag = new ResultListFragment();

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/CardViewFragment.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/CardViewFragment.java
@@ -733,7 +733,7 @@ public class CardViewFragment extends FamiliarFragment {
      *
      * @param item The context menu item that was selected.
      * @return boolean Return false to allow normal context menu processing to proceed, true to
-     *         consume it here.
+     * consume it here.
      */
     @Override
     public boolean onContextItemSelected(android.view.MenuItem item) {
@@ -1204,11 +1204,11 @@ public class CardViewFragment extends FamiliarFragment {
                 /* Some trickery to figure out if we have a token */
                 boolean isToken = false;
                 if (mCardType.contains("Token") || /* try to take the easy way out */
-                    (mCardCMC == 0 && /* Tokens have a CMC of 0 */
+                        (mCardCMC == 0 && /* Tokens have a CMC of 0 */
                     /* The only tokens in Gatherer are from Duel Decks */
-                     mSetName.contains("Duel Decks") &&
+                                mSetName.contains("Duel Decks") &&
                      /* The only tokens in Gatherer are creatures */
-                     mCardType.contains("Creature"))) {
+                                mCardType.contains("Creature"))) {
                     isToken = true;
                 }
 

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/MoJhoStoFragment.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/MoJhoStoFragment.java
@@ -22,6 +22,7 @@ import com.gelakinetic.mtgfam.helpers.database.CardDbAdapter;
 import com.gelakinetic.mtgfam.helpers.database.DatabaseManager;
 import com.gelakinetic.mtgfam.helpers.database.FamiliarDbException;
 
+import java.util.Collections;
 import java.util.Random;
 
 /**
@@ -200,17 +201,17 @@ public class MoJhoStoFragment extends FamiliarFragment {
      */
     private void getOneSpell(String type, int cmc) {
         try {
+            SearchCriteria criteria = new SearchCriteria();
             SQLiteDatabase database = DatabaseManager.getInstance(getActivity(), false).openDatabase(false);
-            String logic = "=";
             if (type.equals(EQUIPMENT)) {
-                logic = "<=";
-                type = " - " + EQUIPMENT;
+                criteria.cmcLogic = "<=";
+                criteria.subTypes = Collections.singletonList(type);
+            } else {
+                criteria.cmcLogic = "=";
+                criteria.superTypes = Collections.singletonList(type);
             }
             String[] returnTypes = new String[]{CardDbAdapter.KEY_ID, CardDbAdapter.KEY_NAME};
-            SearchCriteria criteria = new SearchCriteria();
-            criteria.type = type;
             criteria.cmc = cmc;
-            criteria.cmcLogic = logic;
             criteria.moJhoStoFilter = true;
             Cursor permanents = CardDbAdapter.Search(criteria, false, returnTypes, true, null, database);
 
@@ -251,7 +252,7 @@ public class MoJhoStoFragment extends FamiliarFragment {
             SQLiteDatabase database = DatabaseManager.getInstance(getActivity(), false).openDatabase(false);
             String[] returnTypes = new String[]{CardDbAdapter.KEY_ID, CardDbAdapter.KEY_NAME};
             SearchCriteria criteria = new SearchCriteria();
-            criteria.type = type;
+            criteria.superTypes = Collections.singletonList(type);
             Cursor spells = CardDbAdapter.Search(criteria, false, returnTypes, true, null, database);
 
             if (spells == null) {

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/SearchViewFragment.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/SearchViewFragment.java
@@ -514,21 +514,15 @@ public class SearchViewFragment extends FamiliarFragment {
                 subtype += " " + type;
             }
         }
-        String sets = null;
-        for (String set : mSetField.getObjects()) {
-            if (sets == null) {
-                sets = set;
-            } else {
-                sets += "-" + set;
-            }
-        }
-        searchCriteria.type = supertype.trim() + " - " + subtype.trim();
+
+        searchCriteria.superTypes = mSupertypeField.getObjects();
+        searchCriteria.subTypes = mSubtypeField.getObjects();
         searchCriteria.flavor = mFlavorField.getText().toString().trim();
         searchCriteria.artist = mArtistField.getText().toString().trim();
         searchCriteria.collectorsNumber = mCollectorsNumberField.getText().toString().trim();
-        searchCriteria.set = sets;
-        searchCriteria.mc = mManaCostTextView.getStringFromObjects();
-        searchCriteria.mcLogic = (Comparison) mManaComparisonSpinner.getSelectedItem();
+        searchCriteria.sets = mSetField.getObjects();
+        searchCriteria.manaCost = mManaCostTextView.getObjects();
+        searchCriteria.manaCostLogic = (Comparison) mManaComparisonSpinner.getSelectedItem();
 
         if (searchCriteria.name.length() == 0) {
             searchCriteria.name = null;
@@ -536,8 +530,11 @@ public class SearchViewFragment extends FamiliarFragment {
         if (searchCriteria.text.length() == 0) {
             searchCriteria.text = null;
         }
-        if (searchCriteria.type.length() == 0) {
-            searchCriteria.type = null;
+        if (searchCriteria.superTypes.size() == 0) {
+            searchCriteria.superTypes = null;
+        }
+        if (searchCriteria.subTypes.size() == 0) {
+            searchCriteria.subTypes = null;
         }
         if (searchCriteria.flavor.length() == 0) {
             searchCriteria.flavor = null;
@@ -547,6 +544,12 @@ public class SearchViewFragment extends FamiliarFragment {
         }
         if (searchCriteria.collectorsNumber.length() == 0) {
             searchCriteria.collectorsNumber = null;
+        }
+        if(searchCriteria.manaCost.size() == 0) {
+            searchCriteria.manaCost = null;
+        }
+        if(searchCriteria.sets.size() == 0) {
+            searchCriteria.sets = null;
         }
 
         /* Build a color string. capital letters means the user is search for that color */
@@ -791,19 +794,25 @@ public class SearchViewFragment extends FamiliarFragment {
             oInputStream.close();
 
             mNameField.setText(criteria.name);
-            String delimiter = " - ";
-            String[] type = criteria.type.split(delimiter);
-            if (type.length > 0 && type[0] != null) {
-                mSupertypeField.addObject(type[0]);
-            }
-            if (type.length > 1 && type[1] != null) {
-                /* Concatenate all strings after the first delimiter
-                 * in case there's a hyphen in the subtype
-                 */
-                for (int i = 1; i < type.length; i++) {
-                    mSubtypeField.addObject(type[i]);
+
+            if(null != criteria.superTypes && criteria.superTypes.size() > 0) {
+                for (String supertype : criteria.superTypes) {
+                    mSupertypeField.addObject(supertype);
                 }
             }
+            else {
+                mSupertypeField.clearTextAndTokens();
+            }
+
+            if(null != criteria.subTypes && criteria.subTypes.size() > 0) {
+                for (String subtype : criteria.subTypes) {
+                    mSubtypeField.addObject(subtype);
+                }
+            }
+            else {
+                mSubtypeField.clearTextAndTokens();
+            }
+
             mTextField.setText(criteria.text);
             mArtistField.setText(criteria.artist);
             mFlavorField.setText(criteria.flavor);
@@ -885,20 +894,22 @@ public class SearchViewFragment extends FamiliarFragment {
             mCmcChoice.setSelection(Arrays.asList(getResources().getStringArray(R.array.cmc_spinner))
                     .indexOf(String.valueOf(criteria.cmc)));
 
-            if (criteria.set != null) {
+            if (criteria.sets != null && criteria.sets.size() > 0) {
                 /* Get a list of the persisted sets */
-                for (String set : criteria.set.split("-")) {
+                for (String set : criteria.sets) {
                     mSetField.addObject(set);
                 }
             } else {
                 mSetField.clearTextAndTokens();
             }
-            if (criteria.mc != null) {
-                mManaCostTextView.setObjectsFromString(criteria.mc);
+            if (criteria.manaCost != null && criteria.manaCost.size() > 0) {
+                for (String mana : criteria.manaCost) {
+                    mManaCostTextView.addObject(mana);
+                }
             } else {
                 mManaCostTextView.clearTextAndTokens();
             }
-            mManaComparisonSpinner.setSelection(criteria.mcLogic.ordinal());
+            mManaComparisonSpinner.setSelection(criteria.manaCostLogic.ordinal());
             if (mFormatNames != null) {
                 mSelectedFormat = Arrays.asList(mFormatNames).indexOf(criteria.format);
             }

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/SearchViewFragment.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/SearchViewFragment.java
@@ -545,10 +545,10 @@ public class SearchViewFragment extends FamiliarFragment {
         if (searchCriteria.collectorsNumber.length() == 0) {
             searchCriteria.collectorsNumber = null;
         }
-        if(searchCriteria.manaCost.size() == 0) {
+        if (searchCriteria.manaCost.size() == 0) {
             searchCriteria.manaCost = null;
         }
-        if(searchCriteria.sets.size() == 0) {
+        if (searchCriteria.sets.size() == 0) {
             searchCriteria.sets = null;
         }
 
@@ -795,21 +795,19 @@ public class SearchViewFragment extends FamiliarFragment {
 
             mNameField.setText(criteria.name);
 
-            if(null != criteria.superTypes && criteria.superTypes.size() > 0) {
+            if (null != criteria.superTypes && criteria.superTypes.size() > 0) {
                 for (String supertype : criteria.superTypes) {
                     mSupertypeField.addObject(supertype);
                 }
-            }
-            else {
+            } else {
                 mSupertypeField.clearTextAndTokens();
             }
 
-            if(null != criteria.subTypes && criteria.subTypes.size() > 0) {
+            if (null != criteria.subTypes && criteria.subTypes.size() > 0) {
                 for (String subtype : criteria.subTypes) {
                     mSubtypeField.addObject(subtype);
                 }
-            }
-            else {
+            } else {
                 mSubtypeField.clearTextAndTokens();
             }
 

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/SearchCriteria.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/SearchCriteria.java
@@ -4,18 +4,20 @@ import com.gelakinetic.mtgfam.helpers.database.CardDbAdapter;
 import com.gelakinetic.mtgfam.helpers.model.Comparison;
 
 import java.io.Serializable;
+import java.util.List;
 
 /**
  * Encapsulate all information about a search query. It is serializable to save to a file easily
  */
 public class SearchCriteria implements Serializable {
-    private static final long serialVersionUID = 4712329695735151964L;
+    private static final long serialVersionUID = 4712329695735151965L;
     public String name = null;
     public String text = null;
-    public String type = null;
+    public List<String> superTypes = null;
+    public List<String> subTypes = null;
     public String color = "wubrgl";
     public int colorLogic = 0;
-    public String set = null;
+    public List<String> sets = null;
     public float powChoice = (float) CardDbAdapter.NO_ONE_CARES;
     public String powLogic = null;
     public float touChoice = (float) CardDbAdapter.NO_ONE_CARES;
@@ -32,7 +34,7 @@ public class SearchCriteria implements Serializable {
     public String collectorsNumber = null;
     public String colorIdentity = "wubrgl";
     public int colorIdentityLogic = 0;
-    public String mc = null;
-    public Comparison mcLogic;
+    public List<String> manaCost = null;
+    public Comparison manaCostLogic;
     public boolean moJhoStoFilter;
 }

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/database/CardDbAdapter.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/database/CardDbAdapter.java
@@ -1198,7 +1198,7 @@ public class CardDbAdapter {
 
         if (null != criteria.manaCostLogic && null != criteria.manaCost) {
             StringBuilder manaCost = new StringBuilder();
-            for(String mana : criteria.manaCost) {
+            for (String mana : criteria.manaCost) {
                 manaCost.append('{').append(mana).append('}');
             }
             statement = criteria.manaCostLogic.appendToSql(statement,
@@ -2266,7 +2266,7 @@ public class CardDbAdapter {
      * @param subcategory The integer subcategory, or -1 for no subcategory
      * @param mDb         The database to query
      * @return A Cursor pointing to all rules which match that keyword in that category &
-     *         subcategory
+     * subcategory
      * @throws FamiliarDbException If something goes wrong
      */
     public static Cursor getRulesByKeyword(String keyword, int category, int subcategory,

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/database/CardDbAdapter.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/database/CardDbAdapter.java
@@ -910,47 +910,16 @@ public class CardDbAdapter {
          * types.
          */
 
-        String supertypes = null;
-        String subtypes = null;
-
-        if (criteria.type != null && !criteria.type.matches("\\s*-\\s*")) {
-            boolean containsSupertype = true;
-            if (criteria.type.substring(0, 2).equals("- ")) {
-                containsSupertype = false;
-            }
-            String delimiter = " - ";
-            String[] split = criteria.type.split(delimiter);
-            if (split.length >= 2) {
-                supertypes = split[0];
-
-                /* Concatenate all strings after the first delimiter
-                 * in case there's a hyphen in the subtype
-                 */
-                subtypes = "";
-                boolean first = true;
-                for (int i = 1; i < split.length; i++) {
-                    if (!first) {
-                        subtypes += delimiter;
-                    }
-                    subtypes += split[i];
-                    first = false;
-                }
-            } else if (containsSupertype) {
-                supertypes = criteria.type.replace(" -", "");
-            } else {
-                subtypes = criteria.type.replace("- ", "");
-            }
-        }
+        List<String> supertypes = criteria.superTypes;
+        List<String> subtypes = criteria.subTypes;
 
         if (supertypes != null && !supertypes.isEmpty()) {
-            /* Separate each individual */
-            String[] supertypesParts = supertypes.split(" ");
             /* Concat a leading and a trailing space to the supertype */
             final String supertypeInDb = "' ' || " + DATABASE_TABLE_CARDS + "." + KEY_SUPERTYPE + " || ' '";
 
             switch (criteria.typeLogic) {
                 case 0:
-                    for (String s : supertypesParts) {
+                    for (String s : supertypes) {
                         if (s.contains(EXCLUDE_TOKEN)) {
                             statement += " AND (" + supertypeInDb + " NOT LIKE " +
                                     sanitizeString("% " + s.substring(1) + " %", false) + ")";
@@ -961,7 +930,7 @@ public class CardDbAdapter {
                     break;
                 case 1:
                     boolean firstRun = true;
-                    for (String s : supertypesParts) {
+                    for (String s : supertypes) {
                         if (firstRun) {
                             firstRun = false;
 
@@ -982,7 +951,7 @@ public class CardDbAdapter {
                     statement += ")";
                     break;
                 case 2:
-                    for (String s : supertypesParts) {
+                    for (String s : supertypes) {
                         statement += " AND (" + supertypeInDb + " NOT LIKE " +
                                 sanitizeString("% " + s + " %", false) + ")";
                     }
@@ -993,14 +962,12 @@ public class CardDbAdapter {
         }
 
         if (subtypes != null && !subtypes.isEmpty()) {
-            /* Separate each individual */
-            String[] subtypesParts = subtypes.split(" ");
             /* Concat a leading and a trailing space to the subtype */
             final String subtypeInDb = "' ' || " + DATABASE_TABLE_CARDS + "." + KEY_SUBTYPE + " || ' '";
 
             switch (criteria.typeLogic) {
                 case 0:
-                    for (String s : subtypesParts) {
+                    for (String s : subtypes) {
                         if (s.contains(EXCLUDE_TOKEN)) {
                             statement += " AND (" + subtypeInDb + " NOT LIKE " +
                                     sanitizeString("% " + s.substring(1) + " %", false) + ")";
@@ -1012,7 +979,7 @@ public class CardDbAdapter {
                     break;
                 case 1:
                     boolean firstRun = true;
-                    for (String s : subtypesParts) {
+                    for (String s : subtypes) {
                         if (firstRun) {
                             firstRun = false;
                             if (s.contains(EXCLUDE_TOKEN))
@@ -1031,7 +998,7 @@ public class CardDbAdapter {
                     statement += ")";
                     break;
                 case 2:
-                    for (String s : subtypesParts) {
+                    for (String s : subtypes) {
                         statement += " AND (" + subtypeInDb + " NOT LIKE " +
                                 sanitizeString("% " + s + " %", false) + ")";
                     }
@@ -1178,12 +1145,12 @@ public class CardDbAdapter {
             }
         }
 
-        if (criteria.set != null) {
+        if (criteria.sets != null && criteria.sets.size() > 0) {
             statement += " AND (";
 
             boolean first = true;
 
-            for (String set : criteria.set.split("-")) {
+            for (String set : criteria.sets) {
                 if (first) {
                     first = false;
                 } else {
@@ -1229,9 +1196,13 @@ public class CardDbAdapter {
             statement += ")";
         }
 
-        if (null != criteria.mcLogic) {
-            statement = criteria.mcLogic.appendToSql(statement,
-                    DATABASE_TABLE_CARDS + "." + KEY_MANACOST, criteria.mc);
+        if (null != criteria.manaCostLogic && null != criteria.manaCost) {
+            StringBuilder manaCost = new StringBuilder();
+            for(String mana : criteria.manaCost) {
+                manaCost.append('{').append(mana).append('}');
+            }
+            statement = criteria.manaCostLogic.appendToSql(statement,
+                    DATABASE_TABLE_CARDS + "." + KEY_MANACOST, manaCost.toString());
         }
 
         if (criteria.cmc != -1) {

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/view/ATokenTextView.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/view/ATokenTextView.java
@@ -2,42 +2,13 @@ package com.gelakinetic.mtgfam.helpers.view;
 
 import android.content.Context;
 import android.graphics.Rect;
-import android.os.Parcelable;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
 
 import com.tokenautocomplete.TokenCompleteTextView;
 
 public abstract class ATokenTextView extends TokenCompleteTextView<String> {
-    private class TokenListener implements TokenCompleteTextView.TokenListener<String> {
-        private TokenCompleteTextView.TokenListener<String> tokenListener;
 
-        @Override
-        public void onTokenAdded(String token) {
-            if (this.tokenListener != null) {
-                tokenListener.onTokenAdded(token);
-            }
-        }
-
-        @Override
-        public void onTokenRemoved(String token) {
-            if (ATokenTextView.this.getObjects().isEmpty()) {
-                String value = ATokenTextView.this.getText().toString();
-                if (hasNonSplitChar(value)) {
-                    ATokenTextView.this.clearText();
-                }
-            }
-            if (this.tokenListener != null) {
-                tokenListener.onTokenRemoved(token);
-            }
-        }
-
-        private void setTokenListener(TokenCompleteTextView.TokenListener<String> tokenListener) {
-            this.tokenListener = tokenListener;
-        }
-    }
-
-    private final ATokenTextView.TokenListener tokenListenerWrapper = new ATokenTextView.TokenListener();
     private boolean handleDismiss = false;
 
     public ATokenTextView(Context context, AttributeSet attrs) {
@@ -45,7 +16,6 @@ public abstract class ATokenTextView extends TokenCompleteTextView<String> {
         this.performBestGuess(false);
         this.allowCollapse(true);
         this.setTokenClickStyle(TokenClickStyle.Delete);
-        super.setTokenListener(tokenListenerWrapper);
     }
 
     @Override
@@ -94,36 +64,5 @@ public abstract class ATokenTextView extends TokenCompleteTextView<String> {
         if (handleDismiss) {
             super.dismissDropDown();
         }
-    }
-
-    @Override
-    public void setTokenListener(TokenCompleteTextView.TokenListener<String> l) {
-        tokenListenerWrapper.setTokenListener(l);
-    }
-
-    public void clearTextAndTokens() {
-        if (this.getObjects().isEmpty()) {
-            this.clearText();
-        } else {
-            for (String token : this.getObjects()) {
-                this.removeObject(token);
-            }
-        }
-    }
-
-    private boolean hasNonSplitChar(String s) {
-        for(char c : s.toCharArray()){
-            // These two chars are used for splitting tokens in TokenCompleteTextView
-            // Unfortunately the array splitChar[] is private there.
-            if(c != ',' && c != ';') {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private void clearText() {
-        final Parcelable state = this.onSaveInstanceState();
-        this.onRestoreInstanceState(state);
     }
 }

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/view/ManaCostTextView.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/view/ManaCostTextView.java
@@ -21,8 +21,6 @@ import android.widget.TextView;
 import com.gelakinetic.mtgfam.R;
 import com.tokenautocomplete.FilteredArrayAdapter;
 
-import org.jetbrains.annotations.NotNull;
-
 import java.util.LinkedHashMap;
 
 public class ManaCostTextView extends ATokenTextView {
@@ -126,29 +124,6 @@ public class ManaCostTextView extends ATokenTextView {
         @Override
         protected boolean keepObject(String obj, String mask) {
             return obj.toUpperCase().contains(mask.toUpperCase());
-        }
-    }
-
-    /**
-     * Return the mana cost as a string.
-     * @return the mana cost string.
-     */
-    @NonNull
-    public String getStringFromObjects() {
-        String value = "";
-        for (String part : this.getObjects()) {
-            value += "{" + part + "}";
-        }
-        return value;
-    }
-
-    public void setObjectsFromString(@NotNull String value) {
-        /* Get a list of the persisted mana symbols */
-        if (value.isEmpty()) {
-            return;
-        }
-        for (String symbol : value.split("}")) {
-            this.addObject(symbol + "}");
         }
     }
 

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/view/ManaCostTextView.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/view/ManaCostTextView.java
@@ -26,6 +26,7 @@ import java.util.LinkedHashMap;
 public class ManaCostTextView extends ATokenTextView {
     private static final LinkedHashMap<String, BitmapDrawable> MANA_DRAWABLES = new LinkedHashMap<>();
     private static final LinkedHashMap<String, Integer> MANA_SYMBOLS = new LinkedHashMap<>();
+
     static {
         MANA_SYMBOLS.put("0", R.drawable.glyph_0);
         MANA_SYMBOLS.put("1", R.drawable.glyph_1);

--- a/mobile/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
+++ b/mobile/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
@@ -1037,6 +1037,43 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
         });
     }
 
+    public void clearTextAndTokens() {
+        post(new Runnable() {
+            @Override
+            public void run() {
+                //To make sure all the appropriate callbacks happen, we just want to piggyback on the
+                //existing code that handles deleting spans when the text changes
+                Editable text = getText();
+                if (text == null) {
+                    return;
+                }
+
+                // Remove all hidden tokens
+                ArrayList<TokenImageSpan> toRemove = new ArrayList<>();
+                for (TokenImageSpan span : hiddenSpans) {
+                    toRemove.add(span);
+                }
+                for (TokenImageSpan span : toRemove) {
+                    hiddenSpans.remove(span);
+                    // Remove it from the state and fire the callback
+                    spanWatcher.onSpanRemoved(text, span, 0, 0);
+                }
+
+                updateCountSpan();
+
+                // Then remove all visible tokens
+                TokenImageSpan[] spans = text.getSpans(0, text.length(), TokenImageSpan.class);
+                for (TokenImageSpan span : spans) {
+                    removeSpan(span);
+                }
+
+                // Finally clear any stray non-tokenized text
+                Parcelable state = TokenCompleteTextView.this.onSaveInstanceState();
+                TokenCompleteTextView.this.onRestoreInstanceState(state);
+            }
+        });
+    }
+
     /**
      * Set the count span the current number of hidden objects
      */


### PR DESCRIPTION
Now that the src for tokenautocomplete is in Familiar, add a function which properly clears all objects and stray text.
Removed the kludgy wrapper which we had been using for clearing fields.
clearTextAndTokens() is modeled on removeObject(), but for all objects, and adds code to clear stray text too.