### PR TITLE
Scryfall improvements

### DIFF
--- a/mobile/src/main/java/com/gelakinetic/mtgfam/FamiliarActivity.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/FamiliarActivity.java
@@ -298,13 +298,14 @@ public class FamiliarActivity extends AppCompatActivity {
      *
      * @param stringUrl The URL to open a stream to, in String form
      * @param logWriter A PrintWriter to log debug info to. Can be null
+     * @param ctx       A context to build the User Agent with
      * @return An InputStream to the content at the URL, or null
      * @throws IOException Thrown if something goes terribly wrong
      */
     public static
     @Nullable
-    InputStream getHttpInputStream(String stringUrl, PrintWriter logWriter) throws IOException {
-        return getHttpInputStream(new URL(stringUrl), logWriter, 0);
+    InputStream getHttpInputStream(String stringUrl, PrintWriter logWriter, Context ctx) throws IOException {
+        return getHttpInputStream(new URL(stringUrl), logWriter, ctx, 0);
     }
 
     /**
@@ -312,13 +313,14 @@ public class FamiliarActivity extends AppCompatActivity {
      *
      * @param url       The URL to open a stream to
      * @param logWriter A PrintWriter to log debug info to. Can be null
+     * @param ctx       A context to build the User Agent with
      * @return An InputStream to the content at the URL, or null
      * @throws IOException Thrown if something goes terribly wrong
      */
     public static
     @Nullable
-    InputStream getHttpInputStream(URL url, PrintWriter logWriter) throws IOException {
-        return getHttpInputStream(url, logWriter, 0);
+    InputStream getHttpInputStream(URL url, PrintWriter logWriter, Context ctx) throws IOException {
+        return getHttpInputStream(url, logWriter, ctx, 0);
     }
 
     /**
@@ -327,13 +329,14 @@ public class FamiliarActivity extends AppCompatActivity {
      *
      * @param url            The URL to open a stream to
      * @param logWriter      A PrintWriter to log debug info to. Can be null
+     * @param ctx            A context to build the User Agent with
      * @param recursionLevel The redirect recursion level. Starts at 0, doesn't go past 10
      * @return An InputStream to the content at the URL, or null
      * @throws IOException Thrown if something goes terribly wrong
      */
     private static
     @Nullable
-    InputStream getHttpInputStream(URL url, @Nullable PrintWriter logWriter,
+    InputStream getHttpInputStream(URL url, @Nullable PrintWriter logWriter, Context ctx,
                                    int recursionLevel) throws IOException {
 
         /* Don't allow infinite recursion */
@@ -344,6 +347,14 @@ public class FamiliarActivity extends AppCompatActivity {
         /* Make the URL & connection objects, follow redirects, timeout after 5s */
         HttpURLConnection.setFollowRedirects(true);
         HttpURLConnection connection = (HttpURLConnection) (url).openConnection();
+        String version = "";
+        try {
+            version = ctx.getPackageManager().getPackageInfo(ctx.getPackageName(), 0).versionName;
+        } catch (PackageManager.NameNotFoundException e) {
+            e.printStackTrace();
+        }
+
+        connection.setRequestProperty("User-Agent", ctx.getString(R.string.app_name) + "/" + version);
         connection.setConnectTimeout(5000);
         connection.setInstanceFollowRedirects(true);
 
@@ -400,7 +411,7 @@ public class FamiliarActivity extends AppCompatActivity {
 
             if (nextUrl != null) {
                 /* If there is a URL to follow, follow it */
-                return getHttpInputStream(nextUrl, logWriter, recursionLevel + 1);
+                return getHttpInputStream(nextUrl, logWriter, ctx, recursionLevel + 1);
             } else {
                 /* Otherwise return null */
                 return null;

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/FamiliarActivity.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/FamiliarActivity.java
@@ -206,8 +206,10 @@ public class FamiliarActivity extends AppCompatActivity {
                 startActivity(new Intent(FamiliarActivity.this, FamiliarActivity.class).setAction(Intent.ACTION_MAIN));
             } else if (s.equals(getString(R.string.key_imageCacheSize))) {
                 /* Close the old cache */
-                mImageCache.flush();
-                mImageCache.close();
+                if (mImageCache != null) {
+                    mImageCache.flush();
+                    mImageCache.close();
+                }
 
                 /* Set up the image cache */
                 ImageCache.ImageCacheParams cacheParams = new ImageCache.ImageCacheParams(FamiliarActivity.this, IMAGE_CACHE_DIR);
@@ -1686,7 +1688,7 @@ public class FamiliarActivity extends AppCompatActivity {
             if (mHighlightedDrawable != null) {
                 mHighlightedDrawable.setColorFilter(null);
             }
-            if(textView != null) {
+            if (textView != null) {
                 mHighlightedDrawable = textView.getCompoundDrawables()[0];
                 mHighlightedDrawable.setColorFilter(ContextCompat.getColor(FamiliarActivity.this, getResourceIdFromAttr(R.attr.colorPrimary_attr)), PorterDuff.Mode.SRC_IN);
             }

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/CardViewFragment.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/CardViewFragment.java
@@ -1248,7 +1248,7 @@ public class CardViewFragment extends FamiliarFragment {
                         }
 
                         /* Download the bitmap */
-                        bitmap = BitmapFactory.decodeStream(FamiliarActivity.getHttpInputStream(u, null));
+                        bitmap = BitmapFactory.decodeStream(FamiliarActivity.getHttpInputStream(u, null, getContext()));
                         /* Cache it */
                         getFamiliarActivity().mImageCache.addBitmapToCache(mImageKey, new BitmapDrawable(mActivity.getResources(), bitmap));
                     } catch (Exception e) {
@@ -1467,7 +1467,7 @@ public class CardViewFragment extends FamiliarFragment {
             mRulingsArrayList = new ArrayList<>();
             try {
                 url = new URL("http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=" + mMultiverseId);
-                is = FamiliarActivity.getHttpInputStream(url, null);
+                is = FamiliarActivity.getHttpInputStream(url, null, getContext());
                 if (is == null) {
                     throw new IOException("null stream");
                 }

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/CardViewFragment.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/CardViewFragment.java
@@ -1276,7 +1276,7 @@ public class CardViewFragment extends FamiliarFragment {
             try {
                 /* 16dp */
                 mBorder = (int) TypedValue.applyDimension(
-                        TypedValue.COMPLEX_UNIT_DIP, 32, getResources().getDisplayMetrics());
+                        TypedValue.COMPLEX_UNIT_DIP, 34, getResources().getDisplayMetrics());
                 if (mLoadTo == MAIN_PAGE) {
                     /* Block the worker thread until the size is figured out */
                     synchronized (getWindowSize) {

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/CardViewFragment.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/CardViewFragment.java
@@ -1385,7 +1385,7 @@ public class CardViewFragment extends FamiliarFragment {
          * @return uri of the card image
          */
         private String getScryfallImageUri(int multiverseId) {
-            return "https://api.scryfall.com/cards/multiverse/" + multiverseId + "?format=image";
+            return "https://api.scryfall.com/cards/multiverse/" + multiverseId + "?format=image&version=normal";
         }
 
         /**

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/CardViewFragment.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/CardViewFragment.java
@@ -1276,7 +1276,7 @@ public class CardViewFragment extends FamiliarFragment {
             try {
                 /* 16dp */
                 mBorder = (int) TypedValue.applyDimension(
-                        TypedValue.COMPLEX_UNIT_DIP, 16, getResources().getDisplayMetrics());
+                        TypedValue.COMPLEX_UNIT_DIP, 32, getResources().getDisplayMetrics());
                 if (mLoadTo == MAIN_PAGE) {
                     /* Block the worker thread until the size is figured out */
                     synchronized (getWindowSize) {

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/PreferenceAdapter.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/PreferenceAdapter.java
@@ -775,11 +775,29 @@ edit.putString(context.getString(R.string.key_lastUpdate), lastUpdate);
         edit.apply();
     }
 
-    public static synchronized int getImageCacheSize(@Nullable Context context) {
+    public static synchronized void setImageCacheSize(@Nullable Context context, int cacheSize) {
         if (null == context) {
-            return 12;
+            return;
         }
-        return PreferenceManager.getDefaultSharedPreferences(context).getInt(context.getString(R.string.key_imageCacheSize), 12);
+
+        Editor edit = PreferenceManager.getDefaultSharedPreferences(context).edit();
+        edit.putInt(context.getString(R.string.key_imageCacheSize), cacheSize);
+        edit.apply();
+    }
+
+    public static synchronized int getImageCacheSize(@Nullable Context context) {
+        final int MIN_CACHE_MB = 50;
+        if (null == context) {
+            return MIN_CACHE_MB;
+        }
+        int cacheSize = PreferenceManager.getDefaultSharedPreferences(context).getInt(context.getString(R.string.key_imageCacheSize), MIN_CACHE_MB);
+
+        /* Make sure the cache is at least 50 MB */
+        if (cacheSize < MIN_CACHE_MB) {
+            setImageCacheSize(context, MIN_CACHE_MB);
+            return MIN_CACHE_MB;
+        }
+        return cacheSize;
     }
 
     static synchronized int getNumTutorCardsSearches(@Nullable Context context) {

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/PriceFetchRequest.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/PriceFetchRequest.java
@@ -170,7 +170,7 @@ public class PriceFetchRequest extends SpiceRequest<PriceInfo> {
                 );
 
                 /* Fetch the information from the web */
-                String result = IOUtils.toString(FamiliarActivity.getHttpInputStream(priceUrl, null));
+                String result = IOUtils.toString(FamiliarActivity.getHttpInputStream(priceUrl, null, mContext));
 
                 /* Parse the XML */
                 Document document = loadXMLFromString(result);

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/updaters/CardAndSetParser.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/updaters/CardAndSetParser.java
@@ -93,13 +93,14 @@ class CardAndSetParser {
      * This method checks the hardcoded URL and downloads a list of patches to be checked
      *
      * @param logWriter A writer to print debug statements when things go wrong
+     * @param context   The context to manage preferences with
      * @return An ArrayList of String[] which contains the {Name, URL, Set Code} for each available patch
      */
-    public Manifest readUpdateJsonStream(PrintWriter logWriter) {
+    public Manifest readUpdateJsonStream(Context context, PrintWriter logWriter) {
         Manifest manifest;
 
         try {
-            InputStream stream = FamiliarActivity.getHttpInputStream(PATCHES_URL, logWriter);
+            InputStream stream = FamiliarActivity.getHttpInputStream(PATCHES_URL, logWriter, context);
             if (stream == null) {
                 throw new IOException("No Stream");
             }
@@ -131,7 +132,7 @@ class CardAndSetParser {
         LegalityData legalityData;
 
         try {
-            InputStream stream = FamiliarActivity.getHttpInputStream(LEGALITY_URL, logWriter);
+            InputStream stream = FamiliarActivity.getHttpInputStream(LEGALITY_URL, logWriter, context);
             if (stream == null) {
                 throw new IOException("No Stream");
             }

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/updaters/DbUpdaterService.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/updaters/DbUpdaterService.java
@@ -180,7 +180,7 @@ public class DbUpdaterService extends IntentService {
                 switchToChecking();
 
                 /* Look for new cards */
-                Manifest manifest = parser.readUpdateJsonStream(logWriter);
+                Manifest manifest = parser.readUpdateJsonStream(getApplicationContext(), logWriter);
 
                 if (manifest != null) {
                     /* Make an arraylist of all the current set codes */
@@ -232,7 +232,7 @@ public class DbUpdaterService extends IntentService {
                                 try {
                                     /* Change the notification to the specific set */
                                     switchToUpdating(String.format(getString(R.string.update_updating_set), set.mName));
-                                    InputStream streamToRead = FamiliarActivity.getHttpInputStream(set.mURL, logWriter);
+                                    InputStream streamToRead = FamiliarActivity.getHttpInputStream(set.mURL, logWriter, getApplicationContext());
                                     if (streamToRead != null) {
                                         ArrayList<Card> cardsToAdd = new ArrayList<>();
                                         ArrayList<Expansion> setsToAdd = new ArrayList<>();
@@ -291,7 +291,7 @@ public class DbUpdaterService extends IntentService {
 
                 RulesParser rp = new RulesParser(new Date(lastRulesUpdate), reporter);
 
-                if (rp.needsToUpdate(logWriter)) {
+                if (rp.needsToUpdate(getApplicationContext(), logWriter)) {
                     switchToUpdating(getString(R.string.update_updating_rules));
                     if (rp.parseRules(logWriter)) {
                         ArrayList<RulesParser.RuleItem> rulesToAdd = new ArrayList<>();

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/updaters/MTRIPGParser.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/updaters/MTRIPGParser.java
@@ -105,7 +105,7 @@ class MTRIPGParser {
                 default:
                     throw new FileNotFoundException("Invalid switch"); /* handled below */
             }
-            InputStream stream = FamiliarActivity.getHttpInputStream(urlString, logWriter);
+            InputStream stream = FamiliarActivity.getHttpInputStream(urlString, logWriter, mContext);
             if (stream != null) {
                 updated = parseDocument(mode, stream);
             }

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/updaters/RulesParser.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/updaters/RulesParser.java
@@ -1,5 +1,7 @@
 package com.gelakinetic.mtgfam.helpers.updaters;
 
+import android.content.Context;
+
 import com.gelakinetic.mtgfam.FamiliarActivity;
 
 import java.io.BufferedReader;
@@ -52,12 +54,13 @@ class RulesParser {
      * the file and its date is newer than this.mLastUpdated, true will be returned. Otherwise, it will return false. If
      * true is returned, this.rulesUrl will be populated.
      *
+     * @param context a context to open the HttpInputStream with
      * @return Whether or this the rules need updating.
      */
-    public boolean needsToUpdate(PrintWriter logWriter) {
+    public boolean needsToUpdate(Context context, PrintWriter logWriter) {
 
         try {
-            this.mInputStream = FamiliarActivity.getHttpInputStream(SOURCE, logWriter);
+            this.mInputStream = FamiliarActivity.getHttpInputStream(SOURCE, logWriter, context);
             if (this.mInputStream == null) {
                 throw new IOException("No Stream");
             }

--- a/mobile/src/main/res/layout/card_view_image_dialog.xml
+++ b/mobile/src/main/res/layout/card_view_image_dialog.xml
@@ -9,15 +9,8 @@
 	more details. You should have received a copy of the GNU General Public License 
 	along with MTG Familiar. If not, see <http://www.gnu.org/licenses/>.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent">
-
-    <ImageView
-        android:id="@+id/cardimage"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:adjustViewBounds="true"
-        android:contentDescription="@string/card_view_image" />
-
-</LinearLayout>
+<ImageView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/cardimage"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:contentDescription="@string/card_view_image" />

--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -157,13 +157,13 @@
             android:title="@string/pref_cat_card_cache">
 
             <com.robobunny.preferences.SeekBarPreference
-                android:defaultValue="12"
+                android:defaultValue="50"
                 android:key="@string/key_imageCacheSize"
-                android:max="100"
+                android:max="500"
                 android:summary="@string/pref_image_cache_size_summary"
                 android:title="@string/pref_image_cache_size_title"
                 robobunny:interval="1"
-                robobunny:min="1"
+                robobunny:min="50"
                 robobunny:unitsRight="MB" />
 
         </PreferenceCategory>
@@ -267,8 +267,7 @@
     <!-- Trade and wishlist preferences -->
     <PreferenceScreen android:title="@string/pref_screen_trade_wishlist">
 
-        <PreferenceCategory
-            xmlns:robobunny="http://robobunny.com"
+        <PreferenceCategory xmlns:robobunny="http://robobunny.com"
             android:title="@string/pref_cat_list_general">
 
             <com.robobunny.preferences.SeekBarPreference


### PR DESCRIPTION
1. Download normal sized images instead of large ones
2. Embiggen the default image cache to 50MB from 12MB
3. Add a custom User-Agent to HTTP requests
4. Fixed scaling for image dialogs