### PR TITLE
Retain decklist through screen rotations and fragment switching

### DIFF
--- a/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/DecklistFragment.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/DecklistFragment.java
@@ -78,6 +78,9 @@ public class DecklistFragment extends FamiliarListFragment {
     public String mCurrentDeck = "";
     public static final String DECK_EXTENSION = ".deck";
 
+    public static final String FRAGMENT_TAG = "decklist";
+    public static final String CURRENT_DECKLIST_TAG = "decklist_name";
+
     /**
      * Create the view, pull out UI elements, and set up the listener for the "add cards" button.
      *
@@ -160,7 +163,29 @@ public class DecklistFragment extends FamiliarListFragment {
         mDecklistChain.addComparator(new CardHelpers.CardComparatorColor());
         mDecklistChain.addComparator(new CardHelpers.CardComparatorName());
 
+
+        if (savedInstanceState != null) {
+            mCurrentDeck = savedInstanceState.getBundle(FRAGMENT_TAG).getString(CURRENT_DECKLIST_TAG);
+            readAndCompressDecklist(null, mCurrentDeck);
+        }
+
         return myFragmentView;
+    }
+
+    /**
+     * Create a bundle with information to recreate this exact state
+     * @return
+     */
+    private Bundle saveState() {
+        Bundle state = new Bundle();
+        state.putString(CURRENT_DECKLIST_TAG, mCurrentDeck);
+        return state;
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putBundle(FRAGMENT_TAG, saveState());
     }
 
     /**
@@ -169,6 +194,7 @@ public class DecklistFragment extends FamiliarListFragment {
     @Override
     public void onPause() {
         super.onPause();
+        PreferenceAdapter.setLastLoadedDecklist(getContext(), mCurrentDeck);
         DecklistHelpers.WriteCompressedDecklist(this.getContext(), mCompressedDecklist, getCurrentDeckName());
     }
 
@@ -260,6 +286,7 @@ public class DecklistFragment extends FamiliarListFragment {
 
         super.onResume();
         mCompressedDecklist.clear();
+        mCurrentDeck = PreferenceAdapter.getLastLoadedDecklist(getContext());
         readAndCompressDecklist(null, mCurrentDeck);
         getCardDataAdapter(0).notifyDataSetChanged();
         mDeckCards.setText(getResources().getQuantityString(R.plurals.decklist_cards_count,

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/PreferenceAdapter.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/PreferenceAdapter.java
@@ -1064,4 +1064,22 @@ edit.putString(context.getString(R.string.key_lastUpdate), lastUpdate);
         edit.apply();
     }
 
+    public static synchronized String getLastLoadedDecklist(@Nullable Context context) {
+        if (null == context) {
+            return "";
+        }
+
+        return PreferenceManager.getDefaultSharedPreferences(context).getString(context.getString(R.string.key_LastDecklistLoaded), "");
+    }
+
+    public static synchronized void setLastLoadedDecklist(@Nullable Context context, String deckName) {
+        if (null == context) {
+            return;
+        }
+
+        Editor edit = PreferenceManager.getDefaultSharedPreferences(context).edit();
+        edit.putString(context.getString(R.string.key_LastDecklistLoaded), deckName);
+        edit.apply();
+    }
+
 }

--- a/mobile/src/main/res/values/strings-pref-keys.xml
+++ b/mobile/src/main/res/values/strings-pref-keys.xml
@@ -90,4 +90,5 @@
     <string name="key_deckPrice" translatable="false">deckPrice</string>
     <string name="key_TcgpToken" translatable="false">tcgp_token</string>
     <string name="key_TcgpTokenExpirationDate" translatable="false">tcgp_token_expiration_date</string>
+    <string name="key_LastDecklistLoaded" translatable="false">last_decklist_loaded</string>
 </resources>


### PR DESCRIPTION
Retain the last decklist when switching screens using a Shared Preference
Retain the decklist when screen rotates using savedInstanceState

fixes #362.