### PR TITLE
Add an efficient display mode (unsure what to call it, but its comfy)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.1'
+        classpath 'com.android.tools.build:gradle:7.2.0'
         //classpath //https://plugins.gradle.org/plugin/com.github.spotbugs
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.0'
+        classpath 'com.android.tools.build:gradle:7.2.1'
         //classpath //https://plugins.gradle.org/plugin/com.github.spotbugs
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -134,6 +134,7 @@ android {
         abortOnError false
         disable 'MissingTranslation'
     }
+    namespace 'com.gelakinetic.mtgfam'
 }
 
 dependencies {

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -18,8 +18,7 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.gelakinetic.mtgfam">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/GatheringsFragment.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/GatheringsFragment.java
@@ -77,7 +77,7 @@ public class GatheringsFragment extends FamiliarFragment {
     public void onSaveInstanceState(@NonNull Bundle outState) {
         Gathering savedGathering = new Gathering();
 
-        savedGathering.mDisplayMode = mDisplayModeSpinner.getSelectedItemPosition();
+        savedGathering.mDisplayMode = LifeCounterFragment.DisplayType.values()[mDisplayModeSpinner.getSelectedItemPosition()];
 
         /* Pull all the information about players from the linear layout's children */
         for (int idx = 0; idx < mLinearLayout.getChildCount(); idx++) {
@@ -152,10 +152,7 @@ public class GatheringsFragment extends FamiliarFragment {
             Gathering gathering = (Gathering) savedInstanceState.getSerializable(SAVED_GATHERING_KEY);
 
             assert gathering != null;
-            if (gathering.mDisplayMode >= mDisplayModeSpinner.getAdapter().getCount()) {
-                gathering.mDisplayMode = 0;
-            }
-            mDisplayModeSpinner.setSelection(gathering.mDisplayMode);
+            mDisplayModeSpinner.setSelection(gathering.mDisplayMode.ordinal());
             ArrayList<GatheringsPlayerData> players = gathering.mPlayerList;
             for (GatheringsPlayerData player : players) {
                 AddPlayerRow(player);

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/LifeCounterFragment.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/LifeCounterFragment.java
@@ -447,6 +447,7 @@ public class LifeCounterFragment extends FamiliarFragment implements TextToSpeec
         boolean isPortrait = requireActivity().getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT;
         switch (mDisplayMode) {
             case DISPLAY_NORMAL:
+            case DISPLAY_EFFICIENT:
                 if (isPortrait) {
                     mGridLayout.setOrientation(GridLayout.HORIZONTAL);
                     mGridLayout.setColumnCount(1);

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/LifeCounterFragment.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/LifeCounterFragment.java
@@ -27,6 +27,7 @@ import android.media.MediaPlayer;
 import android.os.Bundle;
 import android.speech.tts.TextToSpeech;
 import android.util.TypedValue;
+import android.view.Display;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -62,9 +63,12 @@ public class LifeCounterFragment extends FamiliarFragment implements TextToSpeec
         AudioManager.OnAudioFocusChangeListener, TextToSpeech.OnUtteranceCompletedListener {
 
     /* constants for display mode */
-    public static final int DISPLAY_NORMAL = 0;
-    public static final int DISPLAY_COMPACT = 1;
-    public static final int DISPLAY_COMMANDER = 2;
+    public enum DisplayType {
+        DISPLAY_NORMAL,
+        DISPLAY_COMPACT,
+        DISPLAY_COMMANDER,
+        DISPLAY_EFFICIENT;
+    }
     /* constants for stat displaying */
     public final static int STAT_LIFE = 0;
     public final static int STAT_POISON = 1;
@@ -81,7 +85,7 @@ public class LifeCounterFragment extends FamiliarFragment implements TextToSpeec
     /* Keeping track of players, display state */
     public final ArrayList<LcPlayer> mPlayers = new ArrayList<>();
     private final LinkedList<String> mVocalizations = new LinkedList<>();
-    public int mDisplayMode = DISPLAY_NORMAL;
+    public DisplayType mDisplayMode = DisplayType.DISPLAY_NORMAL;
     private int mStatDisplaying = STAT_LIFE;
     /* UI Elements, measurement */
     public GridLayout mGridLayout;
@@ -165,7 +169,7 @@ public class LifeCounterFragment extends FamiliarFragment implements TextToSpeec
         assert myFragmentView != null;
         mGridLayout = myFragmentView.findViewById(R.id.playerList);
 
-        mDisplayMode = Integer.parseInt(PreferenceAdapter.getDisplayMode(getContext()));
+        mDisplayMode = DisplayType.values()[Integer.parseInt(PreferenceAdapter.getDisplayMode(getContext()))];
 
         mCommanderPlayerView = myFragmentView.findViewById(R.id.commander_player);
 
@@ -436,7 +440,7 @@ public class LifeCounterFragment extends FamiliarFragment implements TextToSpeec
      */
     public void changeDisplayMode(boolean shouldDefaultLives) {
         /* update the preference */
-        PreferenceAdapter.setDisplayMode(getContext(), String.valueOf(mDisplayMode));
+        PreferenceAdapter.setDisplayMode(getContext(), String.valueOf(mDisplayMode.ordinal()));
 
         mGridLayout.removeAllViews();
 
@@ -507,7 +511,7 @@ public class LifeCounterFragment extends FamiliarFragment implements TextToSpeec
             addPlayerView(player);
         }
 
-        if (mDisplayMode == DISPLAY_COMMANDER) {
+        if (mDisplayMode == DisplayType.DISPLAY_COMMANDER) {
             mCommanderButton.setVisibility(View.VISIBLE);
             mCommanderPlayerView.setVisibility(View.VISIBLE);
             mCommanderPlayerView.removeAllViews();
@@ -539,7 +543,7 @@ public class LifeCounterFragment extends FamiliarFragment implements TextToSpeec
         } catch (IllegalArgumentException e) {
             return;
         }
-        if (mDisplayMode == DISPLAY_COMMANDER) {
+        if (mDisplayMode == DisplayType.DISPLAY_COMMANDER) {
             player.mCommanderRowView.setOnClickListener(view -> {
                 /* Show this player's info in mCommanderPlayerView */
                 mCommanderPlayerView.removeAllViews();
@@ -776,7 +780,7 @@ public class LifeCounterFragment extends FamiliarFragment implements TextToSpeec
      * @return 40 life in commander mode, 20 life otherwise
      */
     private int getDefaultLife() {
-        if (mDisplayMode == DISPLAY_COMMANDER) {
+        if (mDisplayMode == DisplayType.DISPLAY_COMMANDER) {
             return DEFAULT_LIFE_COMMANDER;
         }
         return DEFAULT_LIFE;

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/LifeCounterFragment.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/LifeCounterFragment.java
@@ -440,37 +440,36 @@ public class LifeCounterFragment extends FamiliarFragment implements TextToSpeec
 
         mGridLayout.removeAllViews();
 
-        if (requireActivity().getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT) {
-            switch (mDisplayMode) {
-                case DISPLAY_NORMAL:
+        boolean isPortrait = requireActivity().getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT;
+        switch (mDisplayMode) {
+            case DISPLAY_NORMAL:
+                if (isPortrait) {
                     mGridLayout.setOrientation(GridLayout.HORIZONTAL);
                     mGridLayout.setColumnCount(1);
                     mGridLayout.setRowCount(GridLayout.UNDEFINED);
-                    break;
-                case DISPLAY_COMPACT:
-                    mGridLayout.setOrientation(GridLayout.HORIZONTAL);
-                    mGridLayout.setColumnCount(mNumCols);
-                    mGridLayout.setRowCount(GridLayout.UNDEFINED);
-                    break;
-                case DISPLAY_COMMANDER:
-                    mGridLayout.setOrientation(GridLayout.HORIZONTAL);
-                    mGridLayout.setColumnCount(2);
-                    mGridLayout.setRowCount(GridLayout.UNDEFINED);
-                    break;
-            }
-        } else {
-            switch (mDisplayMode) {
-                case DISPLAY_NORMAL:
+                } else {
                     mGridLayout.setOrientation(GridLayout.VERTICAL);
                     mGridLayout.setColumnCount(GridLayout.UNDEFINED);
                     mGridLayout.setRowCount(1);
-                    break;
-                case DISPLAY_COMPACT:
+                }
+                break;
+            case DISPLAY_COMPACT:
+                if (isPortrait) {
+                    mGridLayout.setOrientation(GridLayout.HORIZONTAL);
+                    mGridLayout.setColumnCount(mNumCols);
+                    mGridLayout.setRowCount(GridLayout.UNDEFINED);
+                } else {
                     mGridLayout.setOrientation(GridLayout.VERTICAL);
                     mGridLayout.setColumnCount(GridLayout.UNDEFINED);
                     mGridLayout.setRowCount(mNumRows);
-                    break;
-                case DISPLAY_COMMANDER:
+                }
+                break;
+            case DISPLAY_COMMANDER:
+                if (isPortrait) {
+                    mGridLayout.setOrientation(GridLayout.HORIZONTAL);
+                    mGridLayout.setColumnCount(2);
+                    mGridLayout.setRowCount(GridLayout.UNDEFINED);
+                } else {
                     mGridLayout.setOrientation(GridLayout.VERTICAL);
                     mGridLayout.setColumnCount(GridLayout.UNDEFINED);
                     if (mListSizeHeight != -1) {
@@ -480,8 +479,8 @@ public class LifeCounterFragment extends FamiliarFragment implements TextToSpeec
                     } else {
                         mGridLayout.setRowCount(GridLayout.UNDEFINED);
                     }
-                    break;
-            }
+                }
+                break;
         }
 
         boolean areLivesDefault = true;

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/dialogs/GatheringsDialogFragment.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/dialogs/GatheringsDialogFragment.java
@@ -230,10 +230,7 @@ public class GatheringsDialogFragment extends FamiliarDialogFragment {
 
                             getParentGatheringsFragment().mCurrentGatheringName = GatheringsIO.ReadGatheringNameFromXML(fGatherings[position],
                                     getActivity().getFilesDir());
-                            if (gathering.mDisplayMode >= getParentGatheringsFragment().mDisplayModeSpinner.getAdapter().getCount()) {
-                                gathering.mDisplayMode = 0;
-                            }
-                            getParentGatheringsFragment().mDisplayModeSpinner.setSelection(gathering.mDisplayMode);
+                            getParentGatheringsFragment().mDisplayModeSpinner.setSelection(gathering.mDisplayMode.ordinal());
                             ArrayList<GatheringsPlayerData> players = gathering.mPlayerList;
                             for (GatheringsPlayerData player : players) {
                                 getParentGatheringsFragment().AddPlayerRow(player);

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/dialogs/LifeCounterDialogFragment.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/dialogs/LifeCounterDialogFragment.java
@@ -28,6 +28,7 @@ import androidx.annotation.Nullable;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.gelakinetic.mtgfam.R;
 import com.gelakinetic.mtgfam.fragments.LifeCounterFragment;
+import com.gelakinetic.mtgfam.fragments.LifeCounterFragment.DisplayType;
 import com.gelakinetic.mtgfam.helpers.LcPlayer;
 import com.gelakinetic.mtgfam.helpers.SnackbarWrapper;
 import com.gelakinetic.mtgfam.helpers.gatherings.Gathering;
@@ -90,7 +91,7 @@ public class LifeCounterDialogFragment extends FamiliarDialogFragment {
                                from the ArrayList and redraw. Also notify other players to remove this player from
                                the commander list, and reset the main commander player view in case that player was
                                removed */
-                            if (getParentLifeCounterFragment().mDisplayMode == LifeCounterFragment.DISPLAY_COMMANDER) {
+                            if (getParentLifeCounterFragment().mDisplayMode == DisplayType.DISPLAY_COMMANDER) {
                                 getParentLifeCounterFragment().mGridLayout.removeView(getParentLifeCounterFragment().mPlayers.get(position).mCommanderRowView);
                             } else {
                                 getParentLifeCounterFragment().mGridLayout.removeView(getParentLifeCounterFragment().mPlayers.get(position).mView);
@@ -101,7 +102,7 @@ public class LifeCounterDialogFragment extends FamiliarDialogFragment {
 
                             getParentLifeCounterFragment().setCommanderInfo(position);
 
-                            if (getParentLifeCounterFragment().mDisplayMode == LifeCounterFragment.DISPLAY_COMMANDER) {
+                            if (getParentLifeCounterFragment().mDisplayMode == DisplayType.DISPLAY_COMMANDER) {
                                 getParentLifeCounterFragment().mCommanderPlayerView.removeAllViews();
                                 if (getParentLifeCounterFragment().mPlayers.size() > 0) {
                                     getParentLifeCounterFragment().mCommanderPlayerView.addView(getParentLifeCounterFragment().mPlayers.get(0).mView);
@@ -145,12 +146,12 @@ public class LifeCounterDialogFragment extends FamiliarDialogFragment {
 
                 builder.title(R.string.pref_display_mode_title);
                 builder.items((CharSequence[]) getResources().getStringArray(R.array.display_array_entries))
-                        .itemsCallbackSingleChoice(getParentLifeCounterFragment().mDisplayMode,
+                        .itemsCallbackSingleChoice(getParentLifeCounterFragment().mDisplayMode.ordinal(),
                                 (dialog, itemView, which, text) -> {
                                     dialog.dismiss();
 
-                                    if (getParentLifeCounterFragment().mDisplayMode != which) {
-                                        getParentLifeCounterFragment().mDisplayMode = which;
+                                    if (getParentLifeCounterFragment().mDisplayMode.ordinal() != which) {
+                                        getParentLifeCounterFragment().mDisplayMode = DisplayType.values()[which];
                                         getParentLifeCounterFragment().changeDisplayMode(true);
                                     }
                                     return true;

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/LcPlayer.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/LcPlayer.java
@@ -19,8 +19,6 @@
 
 package com.gelakinetic.mtgfam.helpers;
 
-import static com.gelakinetic.mtgfam.fragments.LifeCounterFragment.DisplayType.DISPLAY_EFFICIENT;
-
 import android.content.Context;
 import android.os.Bundle;
 import android.os.Handler;

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/LcPlayer.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/LcPlayer.java
@@ -19,6 +19,8 @@
 
 package com.gelakinetic.mtgfam.helpers;
 
+import static com.gelakinetic.mtgfam.fragments.LifeCounterFragment.DisplayType.DISPLAY_EFFICIENT;
+
 import android.content.Context;
 import android.os.Bundle;
 import android.os.Handler;
@@ -294,7 +296,7 @@ public class LcPlayer {
      * Inflate the necessary views for this player, set the onClickListeners, and return the view to be added to the
      * GridView
      *
-     * @param displayMode         The display mode, either DISPLAY_COMMANDER, DISPLAY_COMPACT or DISPLAY_NORMAL
+     * @param displayMode         The display mode
      * @param statType            The stat type being displayed, either STAT_POISON, STAT_LIFE, or STAT_COMMANDER
      * @param playersView         The GridLayout to inflate all players into
      * @param commanderPlayerView The LinearLayout to inflate commander players into
@@ -346,7 +348,7 @@ public class LcPlayer {
 
                 break;
             }
-            case DISPLAY_COMPACT: {
+            case DISPLAY_COMPACT:
                 /* inflate the compact view */
                 mView = LayoutInflater
                         .from(mFragment.getActivity()).inflate(R.layout.life_counter_player_compact, playersView, false);
@@ -356,7 +358,17 @@ public class LcPlayer {
                 mHistoryPoisonAdapter = null;
                 mCommanderDamageAdapter = null;
                 break;
-            }
+            case DISPLAY_EFFICIENT:
+                mView = LayoutInflater
+                        .from(mFragment.getActivity()).inflate(R.layout.life_counter_player_efficient, playersView, false);
+                /* Make new adapters */
+                mHistoryList = mView.findViewById(R.id.player_history);
+                mHistoryLifeAdapter = new HistoryArrayAdapter(mFragment.getActivity(), LifeCounterFragment.STAT_LIFE);
+                mHistoryPoisonAdapter
+                        = new HistoryArrayAdapter(mFragment.getActivity(), LifeCounterFragment.STAT_POISON);
+                /* Don't bother with commander stuff */
+                mCommanderDamageAdapter = null;
+                break;
         }
         assert mView != null;
 

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/LcPlayer.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/LcPlayer.java
@@ -41,6 +41,7 @@ import com.gelakinetic.mtgfam.R;
 import com.gelakinetic.mtgfam.fragments.LifeCounterFragment;
 import com.gelakinetic.mtgfam.fragments.dialogs.FamiliarDialogFragment;
 import com.gelakinetic.mtgfam.fragments.dialogs.LcPlayerDialogFragment;
+import com.gelakinetic.mtgfam.fragments.LifeCounterFragment.DisplayType;
 
 import java.util.ArrayList;
 import java.util.Locale;
@@ -299,12 +300,12 @@ public class LcPlayer {
      * @param commanderPlayerView The LinearLayout to inflate commander players into
      * @return The view to be added to the GridView. Can either be mView or mCommanderRowView
      */
-    public View newView(int displayMode, int statType, GridLayout playersView, LinearLayout commanderPlayerView) {
+    public View newView(DisplayType displayMode, int statType, GridLayout playersView, LinearLayout commanderPlayerView) {
         switch (displayMode) {
-            case LifeCounterFragment.DISPLAY_COMMANDER:
-            case LifeCounterFragment.DISPLAY_NORMAL: {
+            case DISPLAY_COMMANDER:
+            case DISPLAY_NORMAL: {
                 /* Inflate the player view */
-                if (LifeCounterFragment.DISPLAY_COMMANDER == displayMode) {
+                if (DisplayType.DISPLAY_COMMANDER == displayMode) {
                     mView = LayoutInflater.from(mFragment.getActivity()).inflate(R.layout.life_counter_player, commanderPlayerView, false);
                 } else {
                     mView = LayoutInflater.from(mFragment.getActivity()).inflate(R.layout.life_counter_player, playersView, false);
@@ -321,7 +322,7 @@ public class LcPlayer {
                 mCommanderDamageAdapter = new CommanderDamageAdapter(mFragment.getActivity());
 
                 /* If it's commander, also inflate the entry to display in the grid, and set up the casting and experience counter button */
-                if (displayMode == LifeCounterFragment.DISPLAY_COMMANDER) {
+                if (displayMode == DisplayType.DISPLAY_COMMANDER) {
                     setupCommanderCastingButton();
                     setupCommanderExperienceCounterButton();
 
@@ -345,7 +346,7 @@ public class LcPlayer {
 
                 break;
             }
-            case LifeCounterFragment.DISPLAY_COMPACT: {
+            case DISPLAY_COMPACT: {
                 /* inflate the compact view */
                 mView = LayoutInflater
                         .from(mFragment.getActivity()).inflate(R.layout.life_counter_player_compact, playersView, false);
@@ -386,7 +387,7 @@ public class LcPlayer {
 
         setMode(statType);
 
-        if (displayMode == LifeCounterFragment.DISPLAY_COMMANDER) {
+        if (displayMode == DisplayType.DISPLAY_COMMANDER) {
             return mCommanderRowView;
         } else {
             return mView;
@@ -555,14 +556,14 @@ public class LcPlayer {
      * @param isPortrait        The orientation of the device
      * @param isSingle          true if this is the only player, false otherwise
      */
-    public void setSize(int mGridLayoutWidth, int mGridLayoutHeight, int numRows, int numCols, int displayMode, boolean isPortrait, boolean isSingle) {
+    public void setSize(int mGridLayoutWidth, int mGridLayoutHeight, int numRows, int numCols, DisplayType displayMode, boolean isPortrait, boolean isSingle) {
 
         if (null == mView) {
             return;
         }
 
         switch (displayMode) {
-            case LifeCounterFragment.DISPLAY_NORMAL: {
+            case DISPLAY_NORMAL: {
                 ViewGroup.LayoutParams params = mView.getLayoutParams();
                 if (null != params) {
                     if (isSingle) {
@@ -579,7 +580,7 @@ public class LcPlayer {
                 }
                 break;
             }
-            case LifeCounterFragment.DISPLAY_COMPACT: {
+            case DISPLAY_COMPACT: {
                 ViewGroup.LayoutParams params = mView.getLayoutParams();
                 if (null != params) {
                     params.width = mGridLayoutWidth / numCols;
@@ -588,7 +589,7 @@ public class LcPlayer {
                 }
                 break;
             }
-            case LifeCounterFragment.DISPLAY_COMMANDER: {
+            case DISPLAY_COMMANDER: {
                 /* Set the row height to 48dp and the width to some fraction of the screen */
                 if (null != mCommanderRowView) {
                     ViewGroup.LayoutParams rowParams = mCommanderRowView.getLayoutParams();

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/gatherings/Gathering.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/gatherings/Gathering.java
@@ -19,6 +19,8 @@
 
 package com.gelakinetic.mtgfam.helpers.gatherings;
 
+import com.gelakinetic.mtgfam.fragments.LifeCounterFragment;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 
@@ -27,14 +29,14 @@ import java.util.ArrayList;
  */
 public class Gathering implements Serializable {
     public final ArrayList<GatheringsPlayerData> mPlayerList;
-    public int mDisplayMode;
+    public LifeCounterFragment.DisplayType mDisplayMode;
 
     /**
      * Default constructor, make a new mPlayerList and set the display mode to normal (0)
      */
     public Gathering() {
         mPlayerList = new ArrayList<>();
-        mDisplayMode = 0;
+        mDisplayMode = LifeCounterFragment.DisplayType.DISPLAY_NORMAL;
     }
 
     /**
@@ -43,7 +45,7 @@ public class Gathering implements Serializable {
      * @param _playerList  A list of GatheringsPlayerData
      * @param _displayMode The default display mode
      */
-    public Gathering(ArrayList<GatheringsPlayerData> _playerList, int _displayMode) {
+    public Gathering(ArrayList<GatheringsPlayerData> _playerList, LifeCounterFragment.DisplayType _displayMode) {
         mPlayerList = _playerList;
         mDisplayMode = _displayMode;
     }

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/gatherings/GatheringsIO.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/gatherings/GatheringsIO.java
@@ -23,6 +23,7 @@ import android.app.Activity;
 import android.util.Xml;
 
 import com.gelakinetic.mtgfam.R;
+import com.gelakinetic.mtgfam.fragments.LifeCounterFragment;
 import com.gelakinetic.mtgfam.helpers.SnackbarWrapper;
 
 import org.w3c.dom.Document;
@@ -224,11 +225,11 @@ public class GatheringsIO {
             DocumentBuilder db = dbf.newDocumentBuilder();
             dom = db.parse(_gatheringFile);
         } catch (ParserConfigurationException | IOException | SAXException pce) {
-            return new Gathering(playerList, 0);
+            return new Gathering(playerList, LifeCounterFragment.DisplayType.DISPLAY_NORMAL);
         }
 
         if (dom == null)
-            return new Gathering(playerList, 0);
+            return new Gathering(playerList, LifeCounterFragment.DisplayType.DISPLAY_NORMAL);
 
         Element docEle = dom.getDocumentElement();
 
@@ -254,13 +255,13 @@ public class GatheringsIO {
             }
         }
 
-        int displayMode;
+        LifeCounterFragment.DisplayType displayMode;
         Element mode = (Element) docEle.getElementsByTagName("displaymode").item(0);
         if (mode != null) {
             String sMode = mode.getChildNodes().item(0).getNodeValue();
-            displayMode = Integer.parseInt(sMode);
+            displayMode = LifeCounterFragment.DisplayType.values()[Integer.parseInt(sMode)];
         } else {
-            displayMode = 0;
+            displayMode = LifeCounterFragment.DisplayType.DISPLAY_NORMAL;
         }
 
         return new Gathering(playerList, displayMode);

--- a/mobile/src/main/res/layout-land/life_counter_player_efficient.xml
+++ b/mobile/src/main/res/layout-land/life_counter_player_efficient.xml
@@ -34,7 +34,6 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_weight="1"
-            android:text="@string/life_counter_plus_one"
             android:textStyle="bold"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
@@ -88,7 +87,7 @@
                 android:id="@+id/player_history"
                 style="@style/list_view_divider"
                 android:layout_width="match_parent"
-                android:layout_height="60dp"
+                android:layout_height="28dp"
                 android:layout_margin="1dp" />
 
         </LinearLayout>
@@ -115,7 +114,6 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_weight="1"
-            android:text="@string/life_counter_minus_one"
             android:textStyle="bold"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@+id/linearLayout2"
@@ -130,60 +128,5 @@
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:background="?attr/color_drawer_divider_item" />
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="horizontal"
-        android:baselineAligned="false">
-
-        <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:orientation="vertical">
-
-            <TextView
-                android:id="@+id/commanderCastText"
-                style="@style/text.medium"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="center"
-                android:text="@string/life_counter_commander_cast" />
-
-            <Button
-                android:id="@+id/commanderCast"
-                style="?attr/button"
-                android:layout_width="match_parent"
-                android:layout_height="48dp"
-                android:text="@string/mana_pool_zero"
-                android:textStyle="bold"
-                android:visibility="visible" />
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:orientation="vertical">
-
-            <TextView
-                android:id="@+id/commanderExperienceCounterText"
-                style="@style/text.medium"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="center"
-                android:text="@string/life_counter_commander_experience_counter" />
-
-            <Button
-                android:id="@+id/commanderExperienceCounter"
-                style="?attr/button"
-                android:layout_width="match_parent"
-                android:layout_height="48dp"
-                android:text="@string/mana_pool_zero"
-                android:textStyle="bold"
-                android:visibility="visible" />
-        </LinearLayout>
-    </LinearLayout>
 
 </LinearLayout>

--- a/mobile/src/main/res/layout-land/life_counter_player_efficient.xml
+++ b/mobile/src/main/res/layout-land/life_counter_player_efficient.xml
@@ -36,7 +36,6 @@
             android:layout_height="0dp"
             android:layout_weight="1"
             android:elevation="-2dp"
-            android:textStyle="bold"
             app:layout_constraintBottom_toTopOf="@+id/player_minus1"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -53,9 +52,9 @@
             android:text="@string/life_counter_plus_five"
             android:textStyle="bold"
             android:translationY="24dp"
-            app:layout_constraintBottom_toBottomOf="@+id/player_plus1"
+            app:layout_constraintBottom_toTopOf="@+id/linearLayout2"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@+id/player_plus1" />
+            app:layout_constraintStart_toStartOf="parent" />
 
         <LinearLayout
             android:id="@+id/linearLayout2"
@@ -65,7 +64,6 @@
             android:orientation="vertical"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 
@@ -119,10 +117,8 @@
             android:layout_height="0dp"
             android:layout_weight="1"
             android:elevation="-2dp"
-            android:textStyle="bold"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="1.0"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/player_plus1" />
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/mobile/src/main/res/layout-land/life_counter_player_efficient.xml
+++ b/mobile/src/main/res/layout-land/life_counter_player_efficient.xml
@@ -19,8 +19,9 @@
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
     android:orientation="vertical">
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -34,36 +35,39 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_weight="1"
+            android:elevation="-2dp"
             android:textStyle="bold"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/player_minus1"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/linearLayout2"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
         <Button
             android:id="@+id/player_plus5"
             style="?android:attr/buttonBarButtonStyle"
 
-            android:layout_width="0dp"
+            android:layout_width="48dp"
             android:layout_height="48dp"
-            android:layout_marginEnd="20dp"
             android:layout_weight="1"
             android:elevation="2dp"
             android:text="@string/life_counter_plus_five"
             android:textStyle="bold"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="@+id/player_plus1"
-            app:layout_constraintTop_toTopOf="@+id/player_plus1" />
+            android:translationY="24dp"
+            app:layout_constraintBottom_toBottomOf="@+id/player_plus1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/player_plus1" />
 
         <LinearLayout
             android:id="@+id/linearLayout2"
             android:layout_width="100dp"
-            android:layout_height="match_parent"
+            android:layout_height="150dp"
             android:gravity="center|center_vertical"
             android:orientation="vertical"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.5"
-            app:layout_constraintStart_toStartOf="parent">
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
             <TextView
                 android:id="@+id/player_name"
@@ -96,16 +100,16 @@
             android:id="@+id/player_minus5"
             style="?android:attr/buttonBarButtonStyle"
 
-            android:layout_width="0dp"
+            android:layout_width="48dp"
             android:layout_height="48dp"
-            android:layout_marginStart="20dp"
             android:layout_weight="1"
             android:elevation="2dp"
             android:text="@string/life_counter_minus_five"
             android:textStyle="bold"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="@+id/player_minus1"
-            app:layout_constraintTop_toTopOf="parent" />
+            android:translationY="-24dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/linearLayout2" />
 
         <Button
             android:id="@+id/player_minus1"
@@ -114,13 +118,13 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_weight="1"
+            android:elevation="-2dp"
             android:textStyle="bold"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/linearLayout2"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="1.0"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="0.0" />
+            app:layout_constraintTop_toBottomOf="@+id/player_plus1" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <View

--- a/mobile/src/main/res/layout-land/life_counter_player_efficient.xml
+++ b/mobile/src/main/res/layout-land/life_counter_player_efficient.xml
@@ -1,0 +1,189 @@
+<!--
+  ~ Copyright 2017 Adam Feinstein
+  ~
+  ~ This file is part of MTG Familiar.
+  ~
+  ~ MTG Familiar is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ MTG Familiar is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with MTG Familiar.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <Button
+            android:id="@+id/player_plus1"
+            style="?android:attr/buttonBarButtonStyle"
+
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:text="@string/life_counter_plus_one"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/linearLayout2"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <Button
+            android:id="@+id/player_plus5"
+            style="?android:attr/buttonBarButtonStyle"
+
+            android:layout_width="0dp"
+            android:layout_height="48dp"
+            android:layout_marginEnd="20dp"
+            android:layout_weight="1"
+            android:elevation="2dp"
+            android:text="@string/life_counter_plus_five"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@+id/player_plus1"
+            app:layout_constraintTop_toTopOf="@+id/player_plus1" />
+
+        <LinearLayout
+            android:id="@+id/linearLayout2"
+            android:layout_width="100dp"
+            android:layout_height="match_parent"
+            android:gravity="center|center_vertical"
+            android:orientation="vertical"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent">
+
+            <TextView
+                android:id="@+id/player_name"
+                style="@style/text.large"
+                android:layout_width="wrap_content"
+                android:layout_height="48dp"
+                android:gravity="center"
+                android:text="@string/life_counter_default_name" />
+
+            <TextView
+                android:id="@+id/player_readout"
+                style="@style/text.xxxlarge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="-10dp"
+                android:layout_marginBottom="-10dp"
+                android:maxLines="1"
+                android:text="@string/life_counter_twenty" />
+
+            <ListView
+                android:id="@+id/player_history"
+                style="@style/list_view_divider"
+                android:layout_width="match_parent"
+                android:layout_height="60dp"
+                android:layout_margin="1dp" />
+
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/player_minus5"
+            style="?android:attr/buttonBarButtonStyle"
+
+            android:layout_width="0dp"
+            android:layout_height="48dp"
+            android:layout_marginStart="20dp"
+            android:layout_weight="1"
+            android:elevation="2dp"
+            android:text="@string/life_counter_minus_five"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/player_minus1"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <Button
+            android:id="@+id/player_minus1"
+            style="?android:attr/buttonBarButtonStyle"
+
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:text="@string/life_counter_minus_one"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/linearLayout2"
+            app:layout_constraintHorizontal_bias="1.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.0" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <View
+        android:id="@+id/divider"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="?attr/color_drawer_divider_item" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="horizontal"
+        android:baselineAligned="false">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/commanderCastText"
+                style="@style/text.medium"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:text="@string/life_counter_commander_cast" />
+
+            <Button
+                android:id="@+id/commanderCast"
+                style="?attr/button"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"
+                android:text="@string/mana_pool_zero"
+                android:textStyle="bold"
+                android:visibility="visible" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/commanderExperienceCounterText"
+                style="@style/text.medium"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:text="@string/life_counter_commander_experience_counter" />
+
+            <Button
+                android:id="@+id/commanderExperienceCounter"
+                style="?attr/button"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"
+                android:text="@string/mana_pool_zero"
+                android:textStyle="bold"
+                android:visibility="visible" />
+        </LinearLayout>
+    </LinearLayout>
+
+</LinearLayout>

--- a/mobile/src/main/res/layout/life_counter_player_efficient.xml
+++ b/mobile/src/main/res/layout/life_counter_player_efficient.xml
@@ -34,7 +34,6 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_weight="1"
-            android:text="@string/life_counter_plus_one"
             android:textStyle="bold"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
@@ -88,7 +87,7 @@
                 android:id="@+id/player_history"
                 style="@style/list_view_divider"
                 android:layout_width="match_parent"
-                android:layout_height="60dp"
+                android:layout_height="28dp"
                 android:layout_margin="1dp" />
 
         </LinearLayout>
@@ -115,7 +114,6 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_weight="1"
-            android:text="@string/life_counter_minus_one"
             android:textStyle="bold"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@+id/linearLayout2"
@@ -130,60 +128,5 @@
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:background="?attr/color_drawer_divider_item" />
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="horizontal"
-        android:baselineAligned="false">
-
-        <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:orientation="vertical">
-
-            <TextView
-                android:id="@+id/commanderCastText"
-                style="@style/text.medium"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="center"
-                android:text="@string/life_counter_commander_cast" />
-
-            <Button
-                android:id="@+id/commanderCast"
-                style="?attr/button"
-                android:layout_width="match_parent"
-                android:layout_height="48dp"
-                android:text="@string/mana_pool_zero"
-                android:textStyle="bold"
-                android:visibility="visible" />
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:orientation="vertical">
-
-            <TextView
-                android:id="@+id/commanderExperienceCounterText"
-                style="@style/text.medium"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="center"
-                android:text="@string/life_counter_commander_experience_counter" />
-
-            <Button
-                android:id="@+id/commanderExperienceCounter"
-                style="?attr/button"
-                android:layout_width="match_parent"
-                android:layout_height="48dp"
-                android:text="@string/mana_pool_zero"
-                android:textStyle="bold"
-                android:visibility="visible" />
-        </LinearLayout>
-    </LinearLayout>
 
 </LinearLayout>

--- a/mobile/src/main/res/layout/life_counter_player_efficient.xml
+++ b/mobile/src/main/res/layout/life_counter_player_efficient.xml
@@ -34,10 +34,11 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_weight="1"
+            android:elevation="-2dp"
             android:textStyle="bold"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/linearLayout2"
+            app:layout_constraintStart_toEndOf="@+id/player_minus1"
             app:layout_constraintTop_toTopOf="parent" />
 
         <Button
@@ -46,13 +47,12 @@
 
             android:layout_width="0dp"
             android:layout_height="48dp"
-            android:layout_marginEnd="20dp"
             android:layout_weight="1"
             android:elevation="2dp"
             android:text="@string/life_counter_plus_five"
             android:textStyle="bold"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="@+id/player_plus1"
+            app:layout_constraintStart_toEndOf="@+id/linearLayout2"
             app:layout_constraintTop_toTopOf="@+id/player_plus1" />
 
         <LinearLayout
@@ -98,13 +98,12 @@
 
             android:layout_width="0dp"
             android:layout_height="48dp"
-            android:layout_marginStart="20dp"
             android:layout_weight="1"
             android:elevation="2dp"
             android:text="@string/life_counter_minus_five"
             android:textStyle="bold"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="@+id/player_minus1"
+            app:layout_constraintEnd_toStartOf="@+id/linearLayout2"
             app:layout_constraintTop_toTopOf="parent" />
 
         <Button
@@ -114,9 +113,10 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_weight="1"
+            android:elevation="-2dp"
             android:textStyle="bold"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/linearLayout2"
+            app:layout_constraintEnd_toStartOf="@+id/player_plus1"
             app:layout_constraintHorizontal_bias="1.0"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"

--- a/mobile/src/main/res/layout/life_counter_player_efficient.xml
+++ b/mobile/src/main/res/layout/life_counter_player_efficient.xml
@@ -1,0 +1,189 @@
+<!--
+  ~ Copyright 2017 Adam Feinstein
+  ~
+  ~ This file is part of MTG Familiar.
+  ~
+  ~ MTG Familiar is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ MTG Familiar is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with MTG Familiar.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <Button
+            android:id="@+id/player_plus1"
+            style="?android:attr/buttonBarButtonStyle"
+
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:text="@string/life_counter_plus_one"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/linearLayout2"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <Button
+            android:id="@+id/player_plus5"
+            style="?android:attr/buttonBarButtonStyle"
+
+            android:layout_width="0dp"
+            android:layout_height="48dp"
+            android:layout_marginEnd="20dp"
+            android:layout_weight="1"
+            android:elevation="2dp"
+            android:text="@string/life_counter_plus_five"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@+id/player_plus1"
+            app:layout_constraintTop_toTopOf="@+id/player_plus1" />
+
+        <LinearLayout
+            android:id="@+id/linearLayout2"
+            android:layout_width="100dp"
+            android:layout_height="match_parent"
+            android:gravity="center|center_vertical"
+            android:orientation="vertical"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent">
+
+            <TextView
+                android:id="@+id/player_name"
+                style="@style/text.large"
+                android:layout_width="wrap_content"
+                android:layout_height="48dp"
+                android:gravity="center"
+                android:text="@string/life_counter_default_name" />
+
+            <TextView
+                android:id="@+id/player_readout"
+                style="@style/text.xxxlarge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="-10dp"
+                android:layout_marginBottom="-10dp"
+                android:maxLines="1"
+                android:text="@string/life_counter_twenty" />
+
+            <ListView
+                android:id="@+id/player_history"
+                style="@style/list_view_divider"
+                android:layout_width="match_parent"
+                android:layout_height="60dp"
+                android:layout_margin="1dp" />
+
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/player_minus5"
+            style="?android:attr/buttonBarButtonStyle"
+
+            android:layout_width="0dp"
+            android:layout_height="48dp"
+            android:layout_marginStart="20dp"
+            android:layout_weight="1"
+            android:elevation="2dp"
+            android:text="@string/life_counter_minus_five"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/player_minus1"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <Button
+            android:id="@+id/player_minus1"
+            style="?android:attr/buttonBarButtonStyle"
+
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:text="@string/life_counter_minus_one"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/linearLayout2"
+            app:layout_constraintHorizontal_bias="1.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.0" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <View
+        android:id="@+id/divider"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="?attr/color_drawer_divider_item" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="horizontal"
+        android:baselineAligned="false">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/commanderCastText"
+                style="@style/text.medium"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:text="@string/life_counter_commander_cast" />
+
+            <Button
+                android:id="@+id/commanderCast"
+                style="?attr/button"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"
+                android:text="@string/mana_pool_zero"
+                android:textStyle="bold"
+                android:visibility="visible" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/commanderExperienceCounterText"
+                style="@style/text.medium"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:text="@string/life_counter_commander_experience_counter" />
+
+            <Button
+                android:id="@+id/commanderExperienceCounter"
+                style="?attr/button"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"
+                android:text="@string/mana_pool_zero"
+                android:textStyle="bold"
+                android:visibility="visible" />
+        </LinearLayout>
+    </LinearLayout>
+
+</LinearLayout>

--- a/mobile/src/main/res/layout/life_counter_player_efficient.xml
+++ b/mobile/src/main/res/layout/life_counter_player_efficient.xml
@@ -35,7 +35,6 @@
             android:layout_height="0dp"
             android:layout_weight="1"
             android:elevation="-2dp"
-            android:textStyle="bold"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@+id/player_minus1"
@@ -53,7 +52,7 @@
             android:textStyle="bold"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toEndOf="@+id/linearLayout2"
-            app:layout_constraintTop_toTopOf="@+id/player_plus1" />
+            app:layout_constraintTop_toTopOf="parent" />
 
         <LinearLayout
             android:id="@+id/linearLayout2"
@@ -62,7 +61,6 @@
             android:gravity="center|center_vertical"
             android:orientation="vertical"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent">
 
             <TextView
@@ -114,13 +112,10 @@
             android:layout_height="0dp"
             android:layout_weight="1"
             android:elevation="-2dp"
-            android:textStyle="bold"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@+id/player_plus1"
-            app:layout_constraintHorizontal_bias="1.0"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="0.0" />
+            app:layout_constraintTop_toTopOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <View

--- a/mobile/src/main/res/values/arrays.xml
+++ b/mobile/src/main/res/values/arrays.xml
@@ -163,6 +163,7 @@
         <item>@string/life_counter_Normal</item>
         <item>@string/life_counter_Compact</item>
         <item>@string/life_counter_Commander</item>
+        <item>@string/life_counter_Efficient</item>
     </string-array>
     <string-array name="display_array_values">
         <item>0</item>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -254,6 +254,7 @@ Mana pool will also be cleared."</string>
     <string name="life_counter_Commander">"Commander"</string>
     <string name="life_counter_Compact">"Compact"</string>
     <string name="life_counter_Normal">"Normal"</string>
+    <string name="life_counter_Efficient">"Efficient"</string>
     <string name="life_counter_commander_cast">"Commander Casting"</string>
     <string name="life_counter_default_name">"Player"</string>
     <plurals name="life_counter_spoken_life">


### PR DESCRIPTION
The existing display modes all waste like 50% of their area with whitespace. This PR adds one which overlaps a small +5 button on a +1 button that takes up the left and right side of the screen, so you can have slightly fatter fingers. Inspired by proprietary [lifetap](https://play.google.com/store/apps/details?id=com.lifetap) and, first, some random other life counting app I saw my friend use. I swear, open-source stuff has the worst UI usually and there's no good reason for it. I mean, this is still much worse than that app, but its at least the same functionality

It also changes a list of magic static integers into an enum, though after doing it I'm not sure if this is the best idea just from a consistency standpoint. Though seriously, I think lists of magic numbers are inferior to enums in every other way. Let me know if you want it changed back though

Finally, when I opened the project, android studio yelled at me about gradle being out of date for something. I just did what it told me to. I hate gradle I hate gradle