### PR TITLE
Allow dual-face cards to be found by their collector number

### DIFF
--- a/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/database/CardDbAdapter.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/helpers/database/CardDbAdapter.java
@@ -1176,6 +1176,15 @@ public class CardDbAdapter {
                     statement.append(" OR ");
                 }
                 statement.append(DATABASE_TABLE_CARDS + "." + KEY_NUMBER + " LIKE ").append(sanitizeString(part, false));
+                // dual-face card's collector numbers are NNNa for the front face and NNNb
+                // for the back face. However, the 'a' and 'b' markers are not present on the
+                // physical cards, so the number alone should also include 'a' and 'b' variants
+                if (part.matches("\\d+")) {
+                    statement.append(" OR ");
+                    statement.append(DATABASE_TABLE_CARDS + "." + KEY_NUMBER + " LIKE ").append(sanitizeString(part + "a", false));
+                    statement.append(" OR ");
+                    statement.append(DATABASE_TABLE_CARDS + "." + KEY_NUMBER + " LIKE ").append(sanitizeString(part + "b", false));
+                }
             }
             statement.append(")");
         }


### PR DESCRIPTION
The collector numbers of dual-face cards are internally represented as NNNa and NNNb for the front and back face respectively.

This means that a user searching for the collector number NNN will not find either face.

Correct this by including the 'a' and 'b' variants in our search when the user searches for only a number.

Ideally these would be two separate structured fields, but that is left to a future refactor.

Small notes
---------------------------------------------------------------------- 
Performance impact seems to be minimal (This already fast search may perform up to 3x slower). In practice a search over the entire history of magic cards still completes in milliseconds.

The 'a' and 'b' scheme is somewhat hardcoded now, hopefully no new cards are printed with a 3rd face.

I'm sure the string concatenation here is slow, but it's a small price to pay for its convenience.

Fixes #611 