### PR TITLE
Avoid a crash when an external help link has no handler

### DIFF
--- a/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/HtmlDocFragment.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/HtmlDocFragment.java
@@ -125,7 +125,7 @@ public class HtmlDocFragment extends FamiliarFragment {
                     try {
                         requireContext().startActivity(i);
                     } catch (ActivityNotFoundException e) {
-                        Toast.makeText(requireContext(), "No app found to open this link", Toast.LENGTH_SHORT).show();
+                        Toast.makeText(requireContext(), getString(R.string.no_app_to_open_link), Toast.LENGTH_SHORT).show();
                     }
                 }
                 return true;

--- a/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/HtmlDocFragment.java
+++ b/mobile/src/main/java/com/gelakinetic/mtgfam/fragments/HtmlDocFragment.java
@@ -20,6 +20,8 @@
 package com.gelakinetic.mtgfam.fragments;
 
 import android.content.Intent;
+import android.content.ActivityNotFoundException;
+import android.widget.Toast;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteException;
 import android.net.Uri;
@@ -120,7 +122,11 @@ public class HtmlDocFragment extends FamiliarFragment {
                 } else {
                     /* Otherwise launch links externally */
                     Intent i = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-                    requireContext().startActivity(i);
+                    try {
+                        requireContext().startActivity(i);
+                    } catch (ActivityNotFoundException e) {
+                        Toast.makeText(requireContext(), "No app found to open this link", Toast.LENGTH_SHORT).show();
+                    }
                 }
                 return true;
             }

--- a/mobile/src/main/res/values-de/strings.xml
+++ b/mobile/src/main/res/values-de/strings.xml
@@ -638,4 +638,5 @@ Standard ....... Not Legal -->
     <string name="pref_show_price_on_card_view_title">"Preis für die Kartenansicht anzeigen"</string>
     <string name="pref_show_price_on_card_view_summary">"Laden Sie beim Anzeigen einer Karte den Preis sofort auf die Kartenansichtsseite."</string>
     <string name="database_update_available_message">Es ist ein Update für die Kartendatenbank verfügbar. Möchten Sie es herunterladen und installieren?</string>
+    <string name="no_app_to_open_link">Keine App zum Öffnen dieses Links gefunden</string>
 </resources>

--- a/mobile/src/main/res/values-es/strings.xml
+++ b/mobile/src/main/res/values-es/strings.xml
@@ -632,4 +632,5 @@ Standard ....... Not Legal -->
     <string name="pref_show_price_on_card_view_title">"Mostrar precio en la vista de tarjeta"</string>
     <string name="pref_show_price_on_card_view_summary">"Al ver una tarjeta, cargue inmediatamente el precio en la página de la vista de la tarjeta"</string>
     <string name="database_update_available_message">Hay una actualización de la base de datos de tarjetas disponible. ¿Quieres descargarla e instalarla?</string>
+    <string name="no_app_to_open_link">No se encontró ninguna aplicación para abrir este enlace</string>
 </resources>

--- a/mobile/src/main/res/values-fr/strings.xml
+++ b/mobile/src/main/res/values-fr/strings.xml
@@ -614,4 +614,5 @@ Standard ....... Not Legal -->
     <string name="pref_show_price_on_card_view_title">"Afficher le prix sur la vue de la carte"</string>
     <string name="pref_show_price_on_card_view_summary">"Lorsque vous affichez une carte, chargez immédiatement le prix de la page Affichage de la carte"</string>
     <string name="database_update_available_message">Une mise à jour de la base de données de cartes est disponible. Souhaitez-vous la télécharger et l\'installer ?</string>
+    <string name="no_app_to_open_link">Aucune application trouvée pour ouvrir ce lien</string>
 </resources>

--- a/mobile/src/main/res/values-it/strings.xml
+++ b/mobile/src/main/res/values-it/strings.xml
@@ -614,4 +614,5 @@ Standard ....... Not Legal -->
     <string name="pref_show_price_on_card_view_title">"Mostra il prezzo sulla vista delle carte"</string>
     <string name="pref_show_price_on_card_view_summary">"Quando si visualizza una scheda, caricare immediatamente il prezzo sulla pagina Visualizza carta"</string>
     <string name="database_update_available_message">C\'è un aggiornamento disponibile del database delle carte. Vuoi scaricarlo e installarlo?</string>
+    <string name="no_app_to_open_link">Nessuna app trovata per aprire questo link</string>
 </resources>

--- a/mobile/src/main/res/values-pl/strings.xml
+++ b/mobile/src/main/res/values-pl/strings.xml
@@ -627,4 +627,5 @@ Standard ....... Not Legal -->
     <string name="pref_show_price_on_card_view_title">"Pokaż cenę na widok karty"</string>
     <string name="pref_show_price_on_card_view_summary">"Podczas przeglądania karty natychmiast załaduj cenę na stronę widoku karty"</string>
     <string name="database_update_available_message">Dostępna jest aktualizacja bazy danych kart. Czy chcesz ją pobrać i zainstalować?</string>
+    <string name="no_app_to_open_link">Nie znaleziono aplikacji do otwarcia tego linku</string>
 </resources>

--- a/mobile/src/main/res/values-pt/strings.xml
+++ b/mobile/src/main/res/values-pt/strings.xml
@@ -617,4 +617,5 @@ Standard ....... Not Legal -->
     <string name="pref_show_price_on_card_view_title">"Mostrar preço na visualização do cartão"</string>
     <string name="pref_show_price_on_card_view_summary">"Ao visualizar um cartão, carregue imediatamente o preço na página de visualização do cartão"</string>
     <string name="database_update_available_message">Há uma atualização da base de dados de cartões disponível. Gostaria de fazer o download e instalar?</string>
+    <string name="no_app_to_open_link">Nenhum aplicativo encontrado para abrir este link</string>
 </resources>

--- a/mobile/src/main/res/values-sk/strings.xml
+++ b/mobile/src/main/res/values-sk/strings.xml
@@ -628,4 +628,5 @@ Standard ....... Not Legal -->
     <string name="pref_show_price_on_card_view_title">"Zobraziť cenu na zobrazení karty"</string>
     <string name="pref_show_price_on_card_view_summary">"Pri prezeraní karty okamžite načítajte cenu na stránku Zobraziť kartu"</string>
     <string name="database_update_available_message">K dispozícii je aktualizácia databázy kariet. Chcete si ho stiahnuť a nainštalovať?</string>
+    <string name="no_app_to_open_link">Nenašla sa žiadna aplikácia na otvorenie tohto odkazu</string>
 </resources>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -610,4 +610,5 @@ Good luck, and have fun!
     <string name="down">Down</string>
     <string name="up">Up</string>
     <string name="database_update_available_message">There\'s an available card database update. Would you like to download and install it?</string>
+    <string name="no_app_to_open_link">No app found to open this link</string>
 </resources>


### PR DESCRIPTION
This wraps the external link launch in the help document viewer so the app no longer crashes when there is no app available to open the link.

Right now external links are passed to `startActivity` directly, which throws `ActivityNotFoundException` on a device with no handler. With this change the link still opens when a handler exists, and otherwise the exception is caught and a short message is shown.

Closes #655.